### PR TITLE
feat: add edge placement for walls and stylized piece rendering

### DIFF
--- a/src/data/pieces-config.json
+++ b/src/data/pieces-config.json
@@ -2,6 +2,7 @@
   "square_hull": {
     "label": "Square Hull",
     "category": "hull",
+    "placementType": "cell",
     "floorConstraint": "ground_only",
     "maxCount": null,
     "cost": { "wood": 300, "lowGrade": 15 }
@@ -9,6 +10,7 @@
   "triangle_hull": {
     "label": "Triangle Hull",
     "category": "hull",
+    "placementType": "cell",
     "floorConstraint": "ground_only",
     "maxCount": null,
     "cost": { "wood": 150, "lowGrade": 8 }
@@ -16,6 +18,7 @@
   "floor_square": {
     "label": "Square Floor",
     "category": "floor",
+    "placementType": "cell",
     "floorConstraint": "upper_only",
     "maxCount": null,
     "cost": { "wood": 150, "lowGrade": 8 }
@@ -23,6 +26,7 @@
   "floor_triangle": {
     "label": "Triangle Floor",
     "category": "floor",
+    "placementType": "cell",
     "floorConstraint": "upper_only",
     "maxCount": null,
     "cost": { "wood": 75, "lowGrade": 4 }
@@ -30,6 +34,7 @@
   "floor_frame_square": {
     "label": "Square Floor Frame",
     "category": "floor",
+    "placementType": "cell",
     "floorConstraint": "upper_only",
     "maxCount": null,
     "cost": { "wood": 150, "lowGrade": 8 }
@@ -37,6 +42,7 @@
   "floor_frame_triangle": {
     "label": "Triangle Floor Frame",
     "category": "floor",
+    "placementType": "cell",
     "floorConstraint": "upper_only",
     "maxCount": null,
     "cost": { "wood": 75, "lowGrade": 4 }
@@ -44,6 +50,7 @@
   "wall": {
     "label": "Wall",
     "category": "structural",
+    "placementType": "edge",
     "floorConstraint": null,
     "maxCount": null,
     "cost": { "wood": 300, "lowGrade": 15 }
@@ -51,6 +58,7 @@
   "doorway": {
     "label": "Doorway",
     "category": "structural",
+    "placementType": "edge",
     "floorConstraint": null,
     "maxCount": null,
     "cost": { "wood": 210, "lowGrade": 11 }
@@ -58,6 +66,7 @@
   "window": {
     "label": "Window",
     "category": "structural",
+    "placementType": "edge",
     "floorConstraint": null,
     "maxCount": null,
     "cost": { "wood": 210, "lowGrade": 11 }
@@ -65,6 +74,7 @@
   "low_wall": {
     "label": "Low Wall",
     "category": "structural",
+    "placementType": "edge",
     "floorConstraint": null,
     "maxCount": null,
     "cost": { "wood": 150, "lowGrade": 8 }
@@ -72,6 +82,7 @@
   "low_cannon_wall": {
     "label": "Cannon Wall",
     "category": "structural",
+    "placementType": "edge",
     "floorConstraint": null,
     "maxCount": null,
     "cost": { "wood": 150, "lowGrade": 8 }
@@ -79,6 +90,7 @@
   "low_wall_barrier": {
     "label": "Low Barrier",
     "category": "structural",
+    "placementType": "edge",
     "floorConstraint": null,
     "maxCount": null,
     "cost": { "wood": 150, "lowGrade": 8 }
@@ -86,6 +98,7 @@
   "boat_stairs": {
     "label": "Boat Stairs",
     "category": "structural",
+    "placementType": "edge",
     "floorConstraint": null,
     "maxCount": null,
     "cost": { "wood": 300, "lowGrade": 15 }
@@ -93,6 +106,7 @@
   "anchor": {
     "label": "Anchor",
     "category": "deployable",
+    "placementType": "cell",
     "floorConstraint": "ground_only",
     "maxCount": null,
     "cost": { "wood": 250 }
@@ -100,6 +114,7 @@
   "steering_wheel": {
     "label": "Steering Wheel",
     "category": "deployable",
+    "placementType": "cell",
     "floorConstraint": null,
     "maxCount": null,
     "cost": { "wood": 100 }
@@ -107,6 +122,7 @@
   "cannon": {
     "label": "Cannon",
     "category": "deployable",
+    "placementType": "cell",
     "floorConstraint": null,
     "maxCount": null,
     "cost": { "wood": 100, "metalFragments": 200 }
@@ -114,6 +130,7 @@
   "sail": {
     "label": "Sail",
     "category": "deployable",
+    "placementType": "cell",
     "floorConstraint": null,
     "maxCount": 10,
     "cost": { "wood": 150, "tarp": 1 }
@@ -121,6 +138,7 @@
   "boat_engine": {
     "label": "Boat Engine",
     "category": "deployable",
+    "placementType": "cell",
     "floorConstraint": "ground_only",
     "maxCount": null,
     "cost": { "highQualityMetal": 5, "gears": 2, "lowGrade": 50 }

--- a/src/scene/GhostPiece.tsx
+++ b/src/scene/GhostPiece.tsx
@@ -1,30 +1,23 @@
-// src/scene/GhostPiece.tsx
-import piecesConfig from '../data/pieces-config.json'
-import type { PiecesConfig, PieceCategory, XYZ } from '../types'
-
-const config = piecesConfig as PiecesConfig
-
-const CATEGORY_COLORS: Record<PieceCategory, string> = {
-  hull: '#5c4a32',
-  structural: '#4a7a4a',
-  floor: '#4a6a8a',
-  deployable: '#8a4a4a',
-}
+import type { XYZ, PieceSide } from '../types'
+import { PIECE_COLORS, DEFAULT_COLOR, getPiecePosition, getPieceSize } from './pieceGeometry'
 
 interface GhostPieceProps {
   position: XYZ
   type: string
   valid: boolean
+  side?: PieceSide
 }
 
-export default function GhostPiece({ position, type, valid }: GhostPieceProps) {
-  const category = config[type]?.category ?? 'structural'
-  const color = valid ? CATEGORY_COLORS[category] : '#ff3333'
+export default function GhostPiece({ position, type, valid, side }: GhostPieceProps) {
+  const baseColor = PIECE_COLORS[type] ?? DEFAULT_COLOR
+  const color = valid ? baseColor : '#ff3333'
+  const worldPos = getPiecePosition(position, type, side)
+  const size = getPieceSize(type, side)
 
   return (
-    <mesh position={[position.x + 0.5, position.y + 0.5, position.z + 0.5]}>
-      <boxGeometry args={[0.92, 0.92, 0.92]} />
-      <meshStandardMaterial color={color} opacity={0.45} transparent />
+    <mesh position={worldPos}>
+      <boxGeometry args={size} />
+      <meshStandardMaterial color={color} opacity={0.45} transparent roughness={0.85} />
     </mesh>
   )
 }

--- a/src/scene/HitPlane.tsx
+++ b/src/scene/HitPlane.tsx
@@ -1,10 +1,10 @@
-// src/scene/HitPlane.tsx
 import { useState } from 'react'
 import type { ThreeEvent } from '@react-three/fiber'
 import { useStore } from '../store/useStore'
 import { canPlace } from '../utils/validation'
+import { detectSide } from './pieceGeometry'
 import piecesConfig from '../data/pieces-config.json'
-import type { PiecesConfig, XYZ } from '../types'
+import type { PiecesConfig, XYZ, PieceSide } from '../types'
 import GhostPiece from './GhostPiece'
 
 const config = piecesConfig as PiecesConfig
@@ -15,39 +15,58 @@ interface HitPlaneProps {
   floorY: 0 | 1 | 2
 }
 
+interface GhostState {
+  pos: XYZ
+  side?: PieceSide
+}
+
 export default function HitPlane({ floorY }: HitPlaneProps) {
   const selectedPieceType = useStore((s) => s.selectedPieceType)
   const pieces = useStore((s) => s.pieces)
   const coordinateIndex = useStore((s) => s.coordinateIndex)
   const placePiece = useStore((s) => s.placePiece)
-  const [ghostPos, setGhostPos] = useState<XYZ | null>(null)
+  const [ghost, setGhost] = useState<GhostState | null>(null)
 
   if (!selectedPieceType) return null
 
-  function toGridPos(point: { x: number; z: number }): XYZ {
-    const x = Math.max(0, Math.min(GRID_W - 1, Math.floor(point.x)))
-    const z = Math.max(0, Math.min(GRID_L - 1, Math.floor(point.z)))
-    return { x, y: floorY, z }
+  const pieceConfig = config[selectedPieceType]
+  if (!pieceConfig) return null
+  const isEdgePiece = pieceConfig.placementType === 'edge'
+
+  function toGhostState(point: { x: number; z: number }): GhostState {
+    const cellX = Math.max(0, Math.min(GRID_W - 1, Math.floor(point.x)))
+    const cellZ = Math.max(0, Math.min(GRID_L - 1, Math.floor(point.z)))
+    const pos: XYZ = { x: cellX, y: floorY, z: cellZ }
+
+    if (isEdgePiece) {
+      const localX = point.x - cellX
+      const localZ = point.z - cellZ
+      const side = detectSide(localX, localZ)
+      return { pos, side }
+    }
+    return { pos }
   }
 
   function handlePointerMove(e: ThreeEvent<PointerEvent>) {
     e.stopPropagation()
-    setGhostPos(toGridPos(e.point))
+    setGhost(toGhostState(e.point))
   }
 
   function handlePointerLeave() {
-    setGhostPos(null)
+    setGhost(null)
   }
 
   function handleClick(e: ThreeEvent<MouseEvent>) {
     e.stopPropagation()
-    const pos = toGridPos(e.point)
-    if (canPlace(selectedPieceType, pos, pieces, coordinateIndex, config)) {
-      placePiece(selectedPieceType, pos, 0)
+    const state = toGhostState(e.point)
+    if (canPlace(selectedPieceType!, state.pos, pieces, coordinateIndex, config, state.side)) {
+      placePiece(selectedPieceType!, state.pos, 0, state.side)
     }
   }
 
-  const isValid = ghostPos ? canPlace(selectedPieceType, ghostPos, pieces, coordinateIndex, config) : false
+  const isValid = ghost
+    ? canPlace(selectedPieceType, ghost.pos, pieces, coordinateIndex, config, ghost.side)
+    : false
 
   return (
     <>
@@ -61,7 +80,14 @@ export default function HitPlane({ floorY }: HitPlaneProps) {
         <planeGeometry args={[GRID_W, GRID_L]} />
         <meshBasicMaterial visible={false} />
       </mesh>
-      {ghostPos && <GhostPiece position={ghostPos} type={selectedPieceType} valid={isValid} />}
+      {ghost && (
+        <GhostPiece
+          position={ghost.pos}
+          type={selectedPieceType}
+          valid={isValid}
+          side={ghost.side}
+        />
+      )}
     </>
   )
 }

--- a/src/scene/PlacedPieces.tsx
+++ b/src/scene/PlacedPieces.tsx
@@ -1,16 +1,5 @@
-// src/scene/PlacedPieces.tsx
 import { useStore } from '../store/useStore'
-import piecesConfig from '../data/pieces-config.json'
-import type { PiecesConfig, PieceCategory } from '../types'
-
-const config = piecesConfig as PiecesConfig
-
-const CATEGORY_COLORS: Record<PieceCategory, string> = {
-  hull: '#5c4a32',
-  structural: '#4a7a4a',
-  floor: '#4a6a8a',
-  deployable: '#8a4a4a',
-}
+import { PIECE_COLORS, DEFAULT_COLOR, getPiecePosition, getPieceSize } from './pieceGeometry'
 
 export default function PlacedPieces() {
   const pieces = useStore((s) => s.pieces)
@@ -22,14 +11,15 @@ export default function PlacedPieces() {
     <>
       {pieces.map((piece) => {
         if (!visibleLevels.has(piece.position.y as 0 | 1 | 2)) return null
-        const category = config[piece.type]?.category ?? 'structural'
-        const color = CATEGORY_COLORS[category]
+        const color = PIECE_COLORS[piece.type] ?? DEFAULT_COLOR
+        const position = getPiecePosition(piece.position, piece.type, piece.side)
+        const size = getPieceSize(piece.type, piece.side)
         const isDeleteMode = selectedPieceType === null
 
         return (
           <mesh
             key={piece.id}
-            position={[piece.position.x + 0.5, piece.position.y + 0.5, piece.position.z + 0.5]}
+            position={position}
             onClick={(e) => {
               if (isDeleteMode) {
                 e.stopPropagation()
@@ -37,9 +27,10 @@ export default function PlacedPieces() {
               }
             }}
           >
-            <boxGeometry args={[0.92, 0.92, 0.92]} />
+            <boxGeometry args={size} />
             <meshStandardMaterial
               color={color}
+              roughness={0.85}
               opacity={isDeleteMode ? 0.8 : 1}
               transparent={isDeleteMode}
             />

--- a/src/scene/pieceGeometry.ts
+++ b/src/scene/pieceGeometry.ts
@@ -1,0 +1,136 @@
+import type { PieceSide, XYZ } from '../types'
+
+// Visual colors per piece type — wood-like palette
+export const PIECE_COLORS: Record<string, string> = {
+  // Hull — dark weathered wood
+  square_hull: '#4a3222',
+  triangle_hull: '#4a3222',
+  // Floors — lighter planks
+  floor_square: '#6b4c30',
+  floor_triangle: '#6b4c30',
+  floor_frame_square: '#5a4028',
+  floor_frame_triangle: '#5a4028',
+  // Structural — mid-tone wood
+  wall: '#7a5a3a',
+  doorway: '#6b4e35',
+  window: '#6b4e35',
+  low_wall: '#7a5a3a',
+  low_cannon_wall: '#7a5a3a',
+  low_wall_barrier: '#8a6a4a',
+  boat_stairs: '#6b4c30',
+  // Deployables — accent colors
+  anchor: '#555555',
+  steering_wheel: '#8b7355',
+  cannon: '#444444',
+  sail: '#c8b89a',
+  boat_engine: '#666666',
+}
+
+export const DEFAULT_COLOR = '#7a5a3a'
+
+// Geometry dimensions for each piece category/type
+export interface PieceShape {
+  size: [number, number, number] // width, height, depth (before rotation)
+  offset: [number, number, number] // position offset within the cell
+  rotationY: number
+}
+
+export function getCellPieceShape(type: string): PieceShape {
+  // Hull and floor pieces are flat slabs
+  if (type.includes('hull')) {
+    return { size: [0.96, 0.15, 0.96], offset: [0.5, 0.075, 0.5], rotationY: 0 }
+  }
+  if (type.includes('floor')) {
+    return { size: [0.96, 0.1, 0.96], offset: [0.5, 0.05, 0.5], rotationY: 0 }
+  }
+  // Deployables — small items sitting on top of foundation
+  if (type === 'anchor') {
+    return { size: [0.4, 0.5, 0.4], offset: [0.5, 0.25, 0.5], rotationY: 0 }
+  }
+  if (type === 'steering_wheel') {
+    return { size: [0.3, 0.6, 0.3], offset: [0.5, 0.3, 0.5], rotationY: 0 }
+  }
+  if (type === 'cannon') {
+    return { size: [0.35, 0.35, 0.7], offset: [0.5, 0.175, 0.5], rotationY: 0 }
+  }
+  if (type === 'sail') {
+    return { size: [0.1, 1.8, 0.6], offset: [0.5, 0.9, 0.5], rotationY: 0 }
+  }
+  if (type === 'boat_engine') {
+    return { size: [0.5, 0.4, 0.5], offset: [0.5, 0.2, 0.5], rotationY: 0 }
+  }
+  // Default cell piece
+  return { size: [0.92, 0.15, 0.92], offset: [0.5, 0.075, 0.5], rotationY: 0 }
+}
+
+export function getEdgePieceShape(type: string, side: PieceSide): PieceShape {
+  const isNS = side === 'north' || side === 'south'
+  const isLow = type.includes('low') || type.includes('barrier')
+
+  const wallHeight = isLow ? 0.33 : 0.95
+  const wallThickness = 0.08
+
+  // Wall-like pieces
+  const size: [number, number, number] = isNS
+    ? [0.96, wallHeight, wallThickness]
+    : [wallThickness, wallHeight, 0.96]
+
+  const offset = getEdgeOffset(side, wallHeight)
+
+  return { size, offset, rotationY: 0 }
+}
+
+function getEdgeOffset(side: PieceSide, height: number): [number, number, number] {
+  const halfH = height / 2
+  switch (side) {
+    case 'north': return [0.5, halfH, 0]
+    case 'south': return [0.5, halfH, 1]
+    case 'west':  return [0, halfH, 0.5]
+    case 'east':  return [1, halfH, 0.5]
+  }
+}
+
+// Detect which edge of a cell the cursor is closest to
+export function detectSide(localX: number, localZ: number): PieceSide {
+  const dx = Math.min(localX, 1 - localX)
+  const dz = Math.min(localZ, 1 - localZ)
+
+  if (dx < dz) {
+    return localX < 0.5 ? 'west' : 'east'
+  } else {
+    return localZ < 0.5 ? 'north' : 'south'
+  }
+}
+
+// Get the 3D position for a piece
+export function getPiecePosition(
+  cellPos: XYZ,
+  type: string,
+  side?: PieceSide,
+): [number, number, number] {
+  if (side) {
+    const shape = getEdgePieceShape(type, side)
+    return [
+      cellPos.x + shape.offset[0],
+      cellPos.y + shape.offset[1],
+      cellPos.z + shape.offset[2],
+    ]
+  }
+  const shape = getCellPieceShape(type)
+  return [
+    cellPos.x + shape.offset[0],
+    cellPos.y + shape.offset[1],
+    cellPos.z + shape.offset[2],
+  ]
+}
+
+// Get the geometry args for a piece
+export function getPieceSize(
+  type: string,
+  side?: PieceSide,
+): [number, number, number] {
+  if (side) {
+    return getEdgePieceShape(type, side).size
+  }
+  return getCellPieceShape(type).size
+}

--- a/src/store/useStore.ts
+++ b/src/store/useStore.ts
@@ -1,7 +1,6 @@
-// src/store/useStore.ts
 import { create } from 'zustand'
-import { toKey } from '../utils/coordinateKey'
-import type { PlacedPiece, XYZ, PieceRotation } from '../types'
+import { toKey, toEdgeKey } from '../utils/coordinateKey'
+import type { PlacedPiece, XYZ, PieceRotation, PieceSide } from '../types'
 
 interface AppStore {
   pieces: PlacedPiece[]
@@ -10,7 +9,7 @@ interface AppStore {
   selectedPieceType: string | null
   cameraResetFn: (() => void) | null
 
-  placePiece(type: string, position: XYZ, rotation: PieceRotation): void
+  placePiece(type: string, position: XYZ, rotation: PieceRotation, side?: PieceSide): void
   removePiece(id: string): void
   setVisibleLevels(levels: Set<0 | 1 | 2>): void
   selectPieceType(type: string | null): void
@@ -22,7 +21,11 @@ interface AppStore {
 function buildIndex(pieces: PlacedPiece[]): Map<string, string> {
   const index = new Map<string, string>()
   for (const piece of pieces) {
-    index.set(toKey(piece.position), piece.id)
+    if (piece.side) {
+      index.set(toEdgeKey(piece.position, piece.side), piece.id)
+    } else {
+      index.set(toKey(piece.position), piece.id)
+    }
   }
   return index
 }
@@ -34,9 +37,9 @@ export const useStore = create<AppStore>((set) => ({
   selectedPieceType: null,
   cameraResetFn: null,
 
-  placePiece(type, position, rotation) {
+  placePiece(type, position, rotation, side) {
     const id = crypto.randomUUID()
-    const piece: PlacedPiece = { id, type, position, rotation }
+    const piece: PlacedPiece = { id, type, position, rotation, ...(side ? { side } : {}) }
     set((state) => {
       const pieces = [...state.pieces, piece]
       return { pieces, coordinateIndex: buildIndex(pieces) }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,5 +1,3 @@
-// src/types/index.ts
-
 export interface XYZ {
   x: number
   y: number
@@ -8,11 +6,16 @@ export interface XYZ {
 
 export type PieceRotation = 0 | 90 | 180 | 270
 
+export type PieceSide = 'north' | 'south' | 'east' | 'west'
+
+export type PlacementType = 'cell' | 'edge'
+
 export interface PlacedPiece {
   id: string
   type: string
   position: XYZ
   rotation: PieceRotation
+  side?: PieceSide // only set for edge pieces (walls, doorways, etc.)
 }
 
 export type FloorConstraint = 'ground_only' | 'upper_only' | null
@@ -31,6 +34,7 @@ export type PieceCategory = 'hull' | 'structural' | 'floor' | 'deployable'
 export interface PieceConfig {
   label: string
   category: PieceCategory
+  placementType: PlacementType
   floorConstraint: FloorConstraint
   maxCount: number | null
   cost: MaterialCosts

--- a/src/utils/coordinateKey.ts
+++ b/src/utils/coordinateKey.ts
@@ -1,6 +1,8 @@
-import type { XYZ } from '../types'
+import type { XYZ, PieceSide } from '../types'
 
 export const toKey = (pos: XYZ): string => `${pos.x},${pos.y},${pos.z}`
+
+export const toEdgeKey = (pos: XYZ, side: PieceSide): string => `${pos.x},${pos.y},${pos.z},${side}`
 
 export const fromKey = (key: string): XYZ => {
   const [x, y, z] = key.split(',').map(Number)

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -1,5 +1,5 @@
-import type { XYZ, FloorConstraint, PlacedPiece, PiecesConfig } from '../types'
-import { toKey } from './coordinateKey'
+import type { XYZ, FloorConstraint, PlacedPiece, PiecesConfig, PieceSide } from '../types'
+import { toKey, toEdgeKey } from './coordinateKey'
 
 const GRID_X = 5
 const GRID_Z = 11
@@ -18,7 +18,15 @@ export function isFloorAllowed(pos: XYZ, constraint: FloorConstraint): boolean {
   return true
 }
 
-export function isOccupied(pos: XYZ, coordinateIndex: Map<string, string>): boolean {
+export function isCellOccupied(pos: XYZ, coordinateIndex: Map<string, string>): boolean {
+  return coordinateIndex.has(toKey(pos))
+}
+
+export function isEdgeOccupied(pos: XYZ, side: PieceSide, coordinateIndex: Map<string, string>): boolean {
+  return coordinateIndex.has(toEdgeKey(pos, side))
+}
+
+export function hasFoundation(pos: XYZ, coordinateIndex: Map<string, string>): boolean {
   return coordinateIndex.has(toKey(pos))
 }
 
@@ -28,18 +36,31 @@ export function isMaxCountReached(type: string, pieces: PlacedPiece[], config: P
   return pieces.filter(p => p.type === type).length >= maxCount
 }
 
+// Keep old name as alias for backward compat in tests
+export const isOccupied = isCellOccupied
+
 export function canPlace(
   type: string,
   position: XYZ,
   pieces: PlacedPiece[],
   coordinateIndex: Map<string, string>,
   config: PiecesConfig,
+  side?: PieceSide,
 ): boolean {
   if (!isInBounds(position)) return false
   const pieceConfig = config[type]
   if (!pieceConfig) return false
   if (!isFloorAllowed(position, pieceConfig.floorConstraint)) return false
-  if (isOccupied(position, coordinateIndex)) return false
   if (isMaxCountReached(type, pieces, config)) return false
+
+  if (pieceConfig.placementType === 'edge') {
+    if (!side) return false
+    if (isEdgeOccupied(position, side, coordinateIndex)) return false
+    // Edge pieces require a foundation (hull or floor piece) in the cell they attach to
+    if (!hasFoundation(position, coordinateIndex)) return false
+  } else {
+    if (isCellOccupied(position, coordinateIndex)) return false
+  }
+
   return true
 }

--- a/test/costs.test.ts
+++ b/test/costs.test.ts
@@ -3,10 +3,10 @@ import { computeTotalCosts } from '../src/utils/costs'
 import type { PlacedPiece, PiecesConfig } from '../src/types'
 
 const config: PiecesConfig = {
-  wall: { label: 'Wall', category: 'structural', floorConstraint: null, maxCount: null, cost: { wood: 300, lowGrade: 15 } },
-  cannon: { label: 'Cannon', category: 'deployable', floorConstraint: null, maxCount: null, cost: { wood: 100, metalFragments: 200 } },
-  sail: { label: 'Sail', category: 'deployable', floorConstraint: null, maxCount: 10, cost: { wood: 150, tarp: 1 } },
-  boat_engine: { label: 'Boat Engine', category: 'deployable', floorConstraint: 'ground_only', maxCount: null, cost: { highQualityMetal: 5, gears: 2, lowGrade: 50 } },
+  wall: { label: 'Wall', category: 'structural', placementType: 'edge', floorConstraint: null, maxCount: null, cost: { wood: 300, lowGrade: 15 } },
+  cannon: { label: 'Cannon', category: 'deployable', placementType: 'cell', floorConstraint: null, maxCount: null, cost: { wood: 100, metalFragments: 200 } },
+  sail: { label: 'Sail', category: 'deployable', placementType: 'cell', floorConstraint: null, maxCount: 10, cost: { wood: 150, tarp: 1 } },
+  boat_engine: { label: 'Boat Engine', category: 'deployable', placementType: 'cell', floorConstraint: 'ground_only', maxCount: null, cost: { highQualityMetal: 5, gears: 2, lowGrade: 50 } },
 }
 
 const makePiece = (type: string, id: string): PlacedPiece => ({

--- a/test/store.test.ts
+++ b/test/store.test.ts
@@ -6,48 +6,79 @@ beforeEach(() => {
   act(() => useStore.getState().clearAll())
 })
 
-describe('placePiece', () => {
+describe('placePiece — cell', () => {
   it('adds piece to pieces array', () => {
-    act(() => useStore.getState().placePiece('wall', { x: 0, y: 0, z: 0 }, 0))
+    act(() => useStore.getState().placePiece('square_hull', { x: 0, y: 0, z: 0 }, 0))
     expect(useStore.getState().pieces).toHaveLength(1)
-    expect(useStore.getState().pieces[0].type).toBe('wall')
+    expect(useStore.getState().pieces[0].type).toBe('square_hull')
   })
 
-  it('updates coordinateIndex', () => {
-    act(() => useStore.getState().placePiece('wall', { x: 1, y: 0, z: 2 }, 0))
+  it('updates coordinateIndex with cell key', () => {
+    act(() => useStore.getState().placePiece('square_hull', { x: 1, y: 0, z: 2 }, 0))
     expect(useStore.getState().coordinateIndex.has('1,0,2')).toBe(true)
   })
 
   it('assigns unique id to each piece', () => {
     act(() => {
-      useStore.getState().placePiece('wall', { x: 0, y: 0, z: 0 }, 0)
-      useStore.getState().placePiece('wall', { x: 1, y: 0, z: 0 }, 0)
+      useStore.getState().placePiece('square_hull', { x: 0, y: 0, z: 0 }, 0)
+      useStore.getState().placePiece('square_hull', { x: 1, y: 0, z: 0 }, 0)
     })
     const { pieces } = useStore.getState()
     expect(pieces[0].id).not.toBe(pieces[1].id)
   })
 })
 
+describe('placePiece — edge', () => {
+  it('adds edge piece with side property', () => {
+    act(() => useStore.getState().placePiece('wall', { x: 0, y: 0, z: 0 }, 0, 'north'))
+    const piece = useStore.getState().pieces[0]
+    expect(piece.side).toBe('north')
+  })
+
+  it('updates coordinateIndex with edge key', () => {
+    act(() => useStore.getState().placePiece('wall', { x: 0, y: 0, z: 0 }, 0, 'north'))
+    expect(useStore.getState().coordinateIndex.has('0,0,0,north')).toBe(true)
+  })
+
+  it('allows multiple edge pieces on different sides of same cell', () => {
+    act(() => {
+      useStore.getState().placePiece('wall', { x: 0, y: 0, z: 0 }, 0, 'north')
+      useStore.getState().placePiece('wall', { x: 0, y: 0, z: 0 }, 0, 'south')
+    })
+    expect(useStore.getState().pieces).toHaveLength(2)
+    expect(useStore.getState().coordinateIndex.has('0,0,0,north')).toBe(true)
+    expect(useStore.getState().coordinateIndex.has('0,0,0,south')).toBe(true)
+  })
+})
+
 describe('removePiece', () => {
   it('removes piece from pieces array', () => {
-    act(() => useStore.getState().placePiece('wall', { x: 0, y: 0, z: 0 }, 0))
+    act(() => useStore.getState().placePiece('square_hull', { x: 0, y: 0, z: 0 }, 0))
     const id = useStore.getState().pieces[0].id
     act(() => useStore.getState().removePiece(id))
     expect(useStore.getState().pieces).toHaveLength(0)
   })
 
-  it('removes piece from coordinateIndex', () => {
-    act(() => useStore.getState().placePiece('wall', { x: 0, y: 0, z: 0 }, 0))
+  it('removes cell piece from coordinateIndex', () => {
+    act(() => useStore.getState().placePiece('square_hull', { x: 0, y: 0, z: 0 }, 0))
     const id = useStore.getState().pieces[0].id
     act(() => useStore.getState().removePiece(id))
     expect(useStore.getState().coordinateIndex.has('0,0,0')).toBe(false)
+  })
+
+  it('removes edge piece from coordinateIndex', () => {
+    act(() => useStore.getState().placePiece('wall', { x: 0, y: 0, z: 0 }, 0, 'north'))
+    const id = useStore.getState().pieces[0].id
+    act(() => useStore.getState().removePiece(id))
+    expect(useStore.getState().coordinateIndex.has('0,0,0,north')).toBe(false)
   })
 })
 
 describe('clearAll', () => {
   it('empties pieces and coordinateIndex', () => {
     act(() => {
-      useStore.getState().placePiece('wall', { x: 0, y: 0, z: 0 }, 0)
+      useStore.getState().placePiece('square_hull', { x: 0, y: 0, z: 0 }, 0)
+      useStore.getState().placePiece('wall', { x: 0, y: 0, z: 0 }, 0, 'north')
       useStore.getState().clearAll()
     })
     expect(useStore.getState().pieces).toHaveLength(0)
@@ -56,13 +87,21 @@ describe('clearAll', () => {
 })
 
 describe('loadPieces', () => {
-  it('replaces pieces and rebuilds coordinateIndex', () => {
+  it('replaces pieces and rebuilds coordinateIndex for cell pieces', () => {
     const incoming = [
-      { id: 'x1', type: 'wall', position: { x: 2, y: 1, z: 3 }, rotation: 0 as const },
+      { id: 'x1', type: 'square_hull', position: { x: 2, y: 0, z: 3 }, rotation: 0 as const },
     ]
     act(() => useStore.getState().loadPieces(incoming))
     expect(useStore.getState().pieces).toEqual(incoming)
-    expect(useStore.getState().coordinateIndex.get('2,1,3')).toBe('x1')
+    expect(useStore.getState().coordinateIndex.get('2,0,3')).toBe('x1')
+  })
+
+  it('rebuilds coordinateIndex for edge pieces', () => {
+    const incoming = [
+      { id: 'w1', type: 'wall', position: { x: 0, y: 0, z: 0 }, rotation: 0 as const, side: 'east' as const },
+    ]
+    act(() => useStore.getState().loadPieces(incoming))
+    expect(useStore.getState().coordinateIndex.get('0,0,0,east')).toBe('w1')
   })
 })
 

--- a/test/validation.test.ts
+++ b/test/validation.test.ts
@@ -1,21 +1,24 @@
 import { describe, it, expect } from 'vitest'
-import { toKey, fromKey } from '../src/utils/coordinateKey'
-import { isInBounds, isFloorAllowed, isOccupied, isMaxCountReached, canPlace } from '../src/utils/validation'
+import { toKey, fromKey, toEdgeKey } from '../src/utils/coordinateKey'
+import { isInBounds, isFloorAllowed, isOccupied, isMaxCountReached, canPlace, hasFoundation, isEdgeOccupied } from '../src/utils/validation'
 import type { PlacedPiece, PiecesConfig } from '../src/types'
 
 const mockConfig: PiecesConfig = {
-  wall: { label: 'Wall', category: 'structural', floorConstraint: null, maxCount: null, cost: { wood: 300 } },
-  square_hull: { label: 'Square Hull', category: 'hull', floorConstraint: 'ground_only', maxCount: null, cost: { wood: 300 } },
-  floor_square: { label: 'Square Floor', category: 'floor', floorConstraint: 'upper_only', maxCount: null, cost: { wood: 150 } },
-  sail: { label: 'Sail', category: 'deployable', floorConstraint: null, maxCount: 10, cost: { wood: 150 } },
+  wall: { label: 'Wall', category: 'structural', placementType: 'edge', floorConstraint: null, maxCount: null, cost: { wood: 300 } },
+  square_hull: { label: 'Square Hull', category: 'hull', placementType: 'cell', floorConstraint: 'ground_only', maxCount: null, cost: { wood: 300 } },
+  floor_square: { label: 'Square Floor', category: 'floor', placementType: 'cell', floorConstraint: 'upper_only', maxCount: null, cost: { wood: 150 } },
+  sail: { label: 'Sail', category: 'deployable', placementType: 'cell', floorConstraint: null, maxCount: 10, cost: { wood: 150 } },
 }
 
-describe('toKey / fromKey', () => {
+describe('toKey / fromKey / toEdgeKey', () => {
   it('encodes position as string', () => {
     expect(toKey({ x: 1, y: 2, z: 3 })).toBe('1,2,3')
   })
   it('decodes key back to position', () => {
     expect(fromKey('1,2,3')).toEqual({ x: 1, y: 2, z: 3 })
+  })
+  it('encodes edge key with side', () => {
+    expect(toEdgeKey({ x: 1, y: 0, z: 2 }, 'north')).toBe('1,0,2,north')
   })
 })
 
@@ -52,7 +55,7 @@ describe('isFloorAllowed', () => {
   })
 })
 
-describe('isOccupied', () => {
+describe('isOccupied / isEdgeOccupied / hasFoundation', () => {
   it('returns false for empty index', () => {
     expect(isOccupied({ x: 0, y: 0, z: 0 }, new Map())).toBe(false)
   })
@@ -60,11 +63,21 @@ describe('isOccupied', () => {
     const index = new Map([['0,0,0', 'piece-1']])
     expect(isOccupied({ x: 0, y: 0, z: 0 }, index)).toBe(true)
   })
+  it('detects edge occupied', () => {
+    const index = new Map([['0,0,0,north', 'wall-1']])
+    expect(isEdgeOccupied({ x: 0, y: 0, z: 0 }, 'north', index)).toBe(true)
+    expect(isEdgeOccupied({ x: 0, y: 0, z: 0 }, 'south', index)).toBe(false)
+  })
+  it('checks for foundation', () => {
+    const index = new Map([['0,0,0', 'hull-1']])
+    expect(hasFoundation({ x: 0, y: 0, z: 0 }, index)).toBe(true)
+    expect(hasFoundation({ x: 1, y: 0, z: 0 }, index)).toBe(false)
+  })
 })
 
 describe('isMaxCountReached', () => {
   it('returns false when maxCount is null', () => {
-    const pieces: PlacedPiece[] = [{ id: '1', type: 'wall', position: { x: 0, y: 0, z: 0 }, rotation: 0 }]
+    const pieces: PlacedPiece[] = [{ id: '1', type: 'wall', position: { x: 0, y: 0, z: 0 }, rotation: 0, side: 'north' }]
     expect(isMaxCountReached('wall', pieces, mockConfig)).toBe(false)
   })
   it('returns false when count is below maxCount', () => {
@@ -81,25 +94,53 @@ describe('isMaxCountReached', () => {
   })
 })
 
-describe('canPlace', () => {
-  it('returns true for valid placement', () => {
-    expect(canPlace('wall', { x: 0, y: 0, z: 0 }, [], new Map(), mockConfig)).toBe(true)
+describe('canPlace — cell pieces', () => {
+  it('allows hull placement on empty ground cell', () => {
+    expect(canPlace('square_hull', { x: 0, y: 0, z: 0 }, [], new Map(), mockConfig)).toBe(true)
   })
-  it('returns false when out of bounds', () => {
-    expect(canPlace('wall', { x: 5, y: 0, z: 0 }, [], new Map(), mockConfig)).toBe(false)
+  it('rejects cell placement when occupied', () => {
+    const index = new Map([['0,0,0', 'existing']])
+    expect(canPlace('square_hull', { x: 0, y: 0, z: 0 }, [], index, mockConfig)).toBe(false)
   })
-  it('returns false when floor constraint violated', () => {
+  it('rejects out of bounds', () => {
+    expect(canPlace('square_hull', { x: 5, y: 0, z: 0 }, [], new Map(), mockConfig)).toBe(false)
+  })
+  it('rejects floor constraint violation', () => {
     expect(canPlace('square_hull', { x: 0, y: 1, z: 0 }, [], new Map(), mockConfig)).toBe(false)
   })
-  it('returns false when cell is occupied', () => {
-    const index = new Map([['0,0,0', 'existing']])
-    expect(canPlace('wall', { x: 0, y: 0, z: 0 }, [], index, mockConfig)).toBe(false)
-  })
-  it('returns false when max count reached', () => {
+  it('rejects max count exceeded', () => {
     const pieces: PlacedPiece[] = Array.from({ length: 10 }, (_, i) => ({
       id: String(i), type: 'sail', position: { x: i, y: 0, z: 0 }, rotation: 0 as const,
     }))
     const index = new Map(pieces.map(p => [toKey(p.position), p.id]))
     expect(canPlace('sail', { x: 0, y: 0, z: 5 }, pieces, index, mockConfig)).toBe(false)
+  })
+})
+
+describe('canPlace — edge pieces', () => {
+  it('allows wall placement on a side of an existing foundation', () => {
+    const index = new Map([['0,0,0', 'hull-1']]) // foundation exists
+    expect(canPlace('wall', { x: 0, y: 0, z: 0 }, [], index, mockConfig, 'north')).toBe(true)
+  })
+  it('rejects wall without side specified', () => {
+    const index = new Map([['0,0,0', 'hull-1']])
+    expect(canPlace('wall', { x: 0, y: 0, z: 0 }, [], index, mockConfig)).toBe(false)
+  })
+  it('rejects wall on cell with no foundation', () => {
+    expect(canPlace('wall', { x: 0, y: 0, z: 0 }, [], new Map(), mockConfig, 'north')).toBe(false)
+  })
+  it('rejects wall when edge is already occupied', () => {
+    const index = new Map([
+      ['0,0,0', 'hull-1'],
+      ['0,0,0,north', 'wall-1'],
+    ])
+    expect(canPlace('wall', { x: 0, y: 0, z: 0 }, [], index, mockConfig, 'north')).toBe(false)
+  })
+  it('allows wall on different side of same cell', () => {
+    const index = new Map([
+      ['0,0,0', 'hull-1'],
+      ['0,0,0,north', 'wall-1'],
+    ])
+    expect(canPlace('wall', { x: 0, y: 0, z: 0 }, [], index, mockConfig, 'south')).toBe(true)
   })
 })

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -4,7 +4,7 @@
     "target": "es2023",
     "lib": ["ES2023"],
     "module": "esnext",
-    "types": ["node"],
+    "types": ["node", "vitest/config"],
     "skipLibCheck": true,
 
     /* Bundler mode */


### PR DESCRIPTION
Walls, doorways, windows, and other structural pieces now snap to the edges (sides) of hull/floor pieces rather than occupying grid cells. A new PlacementType field ('cell' vs 'edge') in pieces-config drives this. Edge pieces require an existing foundation to attach to and track which side (north/south/east/west) they occupy.

Pieces now render with appropriate shapes: flat slabs for hull/floor, thin rectangles for walls, and distinct proportions for deployables. Wood-like color palette replaces the uniform colored cubes.