### PR TITLE
feat: angle default camera to show 3D depth

### DIFF
--- a/src/scene/Viewport.tsx
+++ b/src/scene/Viewport.tsx
@@ -23,7 +23,7 @@ function SceneSetup() {
     const controls = controlsRef.current
     if (!controls) return
     controls.target.set(...SCENE_CENTER)
-    controls.object.position.set(2.5, 18, 5.5)
+    controls.object.position.set(2.5, 14, 14)
     controls.update()
   }, [])
 
@@ -65,7 +65,7 @@ function ActiveHitPlane() {
 export default function Viewport() {
   return (
     <Canvas
-      camera={{ position: [2.5, 18, 5.5], fov: 50 }}
+      camera={{ position: [2.5, 14, 14], fov: 50 }}
       style={{ width: '100%', height: '100%', background: '#1a1a2e' }}
     >
       <ambientLight intensity={0.6} />


### PR DESCRIPTION
## Summary
- Camera starts at an angled perspective `[2.5, 14, 14]` instead of straight top-down `[2.5, 18, 5.5]`
- Reset Camera button also uses the new angled position
- Gives users an immediate sense of the 3D building space

## Test plan
- [x] Load the app — camera should show the grid at an angle, not flat top-down
- [x] Click Reset Camera — should return to the angled view

🤖 Generated with [Claude Code](https://claude.com/claude-code)