### PR TITLE
fix: right-click to delete placed pieces

### DIFF
--- a/src/scene/PlacedPieces.tsx
+++ b/src/scene/PlacedPieces.tsx
@@ -23,10 +23,15 @@ export default function PlacedPieces() {
           }
         }
 
+        const handleContextMenu = (e: { stopPropagation: () => void }) => {
+          e.stopPropagation()
+          removePiece(piece.id)
+        }
+
         // Edge pieces use EdgeMesh for distinct window/doorway shapes
         if (piece.side) {
           return (
-            <group key={piece.id} position={position} onClick={handleClick}>
+            <group key={piece.id} position={position} onClick={handleClick} onContextMenu={handleContextMenu}>
               <EdgeMesh
                 type={piece.type}
                 side={piece.side}
@@ -40,7 +45,7 @@ export default function PlacedPieces() {
         // Cell pieces use simple box geometry
         const size = getPieceSize(piece.type)
         return (
-          <mesh key={piece.id} position={position} onClick={handleClick}>
+          <mesh key={piece.id} position={position} onClick={handleClick} onContextMenu={handleContextMenu}>
             <boxGeometry args={size} />
             <meshStandardMaterial
               color={color}

--- a/src/scene/Viewport.tsx
+++ b/src/scene/Viewport.tsx
@@ -67,6 +67,7 @@ export default function Viewport() {
     <Canvas
       camera={{ position: [2.5, 14, 14], fov: 50 }}
       style={{ width: '100%', height: '100%', background: '#1a1a2e' }}
+      onContextMenu={(e) => e.preventDefault()}
     >
       <ambientLight intensity={0.6} />
       <directionalLight position={[5, 10, 5]} intensity={0.8} />


### PR DESCRIPTION
## Summary
- Right-clicking any placed piece removes it, regardless of selection state
- Browser context menu suppressed on the 3D canvas
- Left-click delete in deselect mode still works as before

## Test plan
- [x] Right-click a placed piece while a piece type is selected — should delete it
- [x] Right-click a placed piece with nothing selected — should delete it
- [x] Left-click delete in deselect mode still works
- [x] No browser context menu appears on the canvas

🤖 Generated with [Claude Code](https://claude.com/claude-code)