### PR TITLE
feat: click to select piece, Delete key to remove

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,12 +18,20 @@ export default function App() {
   const selectPieceType = useStore((s) => s.selectPieceType)
   const undo = useStore((s) => s.undo)
   const redo = useStore((s) => s.redo)
+  const deleteSelectedPiece = useStore((s) => s.deleteSelectedPiece)
+  const selectPiece = useStore((s) => s.selectPiece)
   const [shareLabel, setShareLabel] = useState('Share')
 
   // Keyboard shortcuts
   useEffect(() => {
     function handleKeyDown(e: KeyboardEvent) {
-      if (e.key === 'Escape') selectPieceType(null)
+      if (e.key === 'Escape') {
+        selectPieceType(null)
+        selectPiece(null)
+      }
+      if (e.key === 'Delete' || e.key === 'Backspace') {
+        deleteSelectedPiece()
+      }
       if ((e.ctrlKey || e.metaKey) && e.key === 'z' && !e.shiftKey) {
         e.preventDefault()
         undo()
@@ -35,7 +43,7 @@ export default function App() {
     }
     window.addEventListener('keydown', handleKeyDown)
     return () => window.removeEventListener('keydown', handleKeyDown)
-  }, [selectPieceType, undo, redo])
+  }, [selectPieceType, undo, redo, deleteSelectedPiece, selectPiece])
 
   function handleShare() {
     const encoded = encodePieces(pieces)

--- a/src/scene/PlacedPieces.tsx
+++ b/src/scene/PlacedPieces.tsx
@@ -19,22 +19,19 @@ export default function PlacedPieces() {
         const position = getPiecePosition(piece.position, piece.type, piece.side)
         const isSelectMode = selectedPieceType === null
 
+        const canSelect = isSelectMode || piece.type === selectedPieceType
+
         const handleClick = (e: { stopPropagation: () => void }) => {
-          if (isSelectMode) {
+          if (canSelect) {
             e.stopPropagation()
             selectPiece(isSelected ? null : piece.id)
           }
         }
 
-        const handleContextMenu = (e: { stopPropagation: () => void }) => {
-          e.stopPropagation()
-          removePiece(piece.id)
-        }
-
         // Edge pieces use EdgeMesh for distinct window/doorway shapes
         if (piece.side) {
           return (
-            <group key={piece.id} position={position} onClick={handleClick} onContextMenu={handleContextMenu}>
+            <group key={piece.id} position={position} onClick={handleClick}>
               <EdgeMesh
                 type={piece.type}
                 side={piece.side}
@@ -48,7 +45,7 @@ export default function PlacedPieces() {
         // Cell pieces use simple box geometry
         const size = getPieceSize(piece.type)
         return (
-          <mesh key={piece.id} position={position} onClick={handleClick} onContextMenu={handleContextMenu}>
+          <mesh key={piece.id} position={position} onClick={handleClick}>
             <boxGeometry args={size} />
             <meshStandardMaterial
               color={color}

--- a/src/scene/PlacedPieces.tsx
+++ b/src/scene/PlacedPieces.tsx
@@ -6,20 +6,23 @@ export default function PlacedPieces() {
   const pieces = useStore((s) => s.pieces)
   const visibleLevels = useStore((s) => s.visibleLevels)
   const selectedPieceType = useStore((s) => s.selectedPieceType)
-  const removePiece = useStore((s) => s.removePiece)
+  const selectedPieceId = useStore((s) => s.selectedPieceId)
+  const selectPiece = useStore((s) => s.selectPiece)
 
   return (
     <>
       {pieces.map((piece) => {
         if (!visibleLevels.has(piece.position.y as 0 | 1 | 2)) return null
-        const color = PIECE_COLORS[piece.type] ?? DEFAULT_COLOR
+        const isSelected = piece.id === selectedPieceId
+        const baseColor = PIECE_COLORS[piece.type] ?? DEFAULT_COLOR
+        const color = isSelected ? '#ff6666' : baseColor
         const position = getPiecePosition(piece.position, piece.type, piece.side)
-        const isDeleteMode = selectedPieceType === null
+        const isSelectMode = selectedPieceType === null
 
         const handleClick = (e: { stopPropagation: () => void }) => {
-          if (isDeleteMode) {
+          if (isSelectMode) {
             e.stopPropagation()
-            removePiece(piece.id)
+            selectPiece(isSelected ? null : piece.id)
           }
         }
 
@@ -36,7 +39,7 @@ export default function PlacedPieces() {
                 type={piece.type}
                 side={piece.side}
                 color={color}
-                opacity={isDeleteMode ? 0.8 : 1}
+                opacity={isSelectMode ? 0.8 : 1}
               />
             </group>
           )
@@ -50,8 +53,8 @@ export default function PlacedPieces() {
             <meshStandardMaterial
               color={color}
               roughness={0.85}
-              opacity={isDeleteMode ? 0.8 : 1}
-              transparent={isDeleteMode}
+              opacity={isSelectMode ? 0.8 : 1}
+              transparent={isSelectMode}
             />
           </mesh>
         )

--- a/src/store/useStore.ts
+++ b/src/store/useStore.ts
@@ -9,6 +9,7 @@ interface AppStore {
   coordinateIndex: Map<string, string>
   visibleLevels: Set<0 | 1 | 2>
   selectedPieceType: string | null
+  selectedPieceId: string | null
   cameraResetFn: (() => void) | null
 
   // History for undo/redo
@@ -19,6 +20,8 @@ interface AppStore {
   removePiece(id: string): void
   setVisibleLevels(levels: Set<0 | 1 | 2>): void
   selectPieceType(type: string | null): void
+  selectPiece(id: string | null): void
+  deleteSelectedPiece(): void
   clearAll(): void
   loadPieces(pieces: PlacedPiece[]): void
   setCameraResetFn(fn: () => void): void
@@ -49,6 +52,7 @@ export const useStore = create<AppStore>((set) => ({
   coordinateIndex: new Map(),
   visibleLevels: new Set([0, 1, 2]),
   selectedPieceType: null,
+  selectedPieceId: null,
   cameraResetFn: null,
   _history: [],
   _future: [],
@@ -73,6 +77,7 @@ export const useStore = create<AppStore>((set) => ({
       return {
         pieces,
         coordinateIndex: buildIndex(pieces),
+        selectedPieceId: null,
         _history: pushHistory(state._history, state.pieces),
         _future: [],
       }
@@ -84,7 +89,25 @@ export const useStore = create<AppStore>((set) => ({
   },
 
   selectPieceType(type) {
-    set({ selectedPieceType: type })
+    set({ selectedPieceType: type, selectedPieceId: null })
+  },
+
+  selectPiece(id) {
+    set({ selectedPieceId: id })
+  },
+
+  deleteSelectedPiece() {
+    set((state) => {
+      if (!state.selectedPieceId) return state
+      const pieces = state.pieces.filter((p) => p.id !== state.selectedPieceId)
+      return {
+        pieces,
+        coordinateIndex: buildIndex(pieces),
+        selectedPieceId: null,
+        _history: pushHistory(state._history, state.pieces),
+        _future: [],
+      }
+    })
   },
 
   clearAll() {


### PR DESCRIPTION
## Summary
- Click a piece (in select mode) to highlight it red
- Press Delete or Backspace to remove the selected piece
- Escape deselects both piece type and selected piece
- No right-click interference with camera orbit

## Test plan
- [x] Click a placed piece with no piece type selected — should highlight red
- [x] Press Delete — highlighted piece should be removed
- [x] Press Escape — selection should clear
- [x] Camera right-click orbit should work normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)