### PR TITLE
feat: Ctrl+Z undo and Ctrl+Y redo

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,16 +16,26 @@ export default function App() {
   const pieces = useStore((s) => s.pieces)
   const cameraResetFn = useStore((s) => s.cameraResetFn)
   const selectPieceType = useStore((s) => s.selectPieceType)
+  const undo = useStore((s) => s.undo)
+  const redo = useStore((s) => s.redo)
   const [shareLabel, setShareLabel] = useState('Share')
 
-  // Escape key deselects active piece type
+  // Keyboard shortcuts
   useEffect(() => {
     function handleKeyDown(e: KeyboardEvent) {
       if (e.key === 'Escape') selectPieceType(null)
+      if ((e.ctrlKey || e.metaKey) && e.key === 'z' && !e.shiftKey) {
+        e.preventDefault()
+        undo()
+      }
+      if ((e.ctrlKey || e.metaKey) && (e.key === 'y' || (e.key === 'z' && e.shiftKey))) {
+        e.preventDefault()
+        redo()
+      }
     }
     window.addEventListener('keydown', handleKeyDown)
     return () => window.removeEventListener('keydown', handleKeyDown)
-  }, [selectPieceType])
+  }, [selectPieceType, undo, redo])
 
   function handleShare() {
     const encoded = encodePieces(pieces)

--- a/src/store/useStore.ts
+++ b/src/store/useStore.ts
@@ -2,12 +2,18 @@ import { create } from 'zustand'
 import { toKey, toEdgeKey } from '../utils/coordinateKey'
 import type { PlacedPiece, XYZ, PieceRotation, PieceSide } from '../types'
 
+const MAX_HISTORY = 50
+
 interface AppStore {
   pieces: PlacedPiece[]
   coordinateIndex: Map<string, string>
   visibleLevels: Set<0 | 1 | 2>
   selectedPieceType: string | null
   cameraResetFn: (() => void) | null
+
+  // History for undo/redo
+  _history: PlacedPiece[][]
+  _future: PlacedPiece[][]
 
   placePiece(type: string, position: XYZ, rotation: PieceRotation, side?: PieceSide): void
   removePiece(id: string): void
@@ -16,6 +22,8 @@ interface AppStore {
   clearAll(): void
   loadPieces(pieces: PlacedPiece[]): void
   setCameraResetFn(fn: () => void): void
+  undo(): void
+  redo(): void
 }
 
 function buildIndex(pieces: PlacedPiece[]): Map<string, string> {
@@ -30,26 +38,44 @@ function buildIndex(pieces: PlacedPiece[]): Map<string, string> {
   return index
 }
 
+function pushHistory(history: PlacedPiece[][], current: PlacedPiece[]): PlacedPiece[][] {
+  const next = [...history, current]
+  if (next.length > MAX_HISTORY) next.shift()
+  return next
+}
+
 export const useStore = create<AppStore>((set) => ({
   pieces: [],
   coordinateIndex: new Map(),
   visibleLevels: new Set([0, 1, 2]),
   selectedPieceType: null,
   cameraResetFn: null,
+  _history: [],
+  _future: [],
 
   placePiece(type, position, rotation, side) {
     const id = crypto.randomUUID()
     const piece: PlacedPiece = { id, type, position, rotation, ...(side ? { side } : {}) }
     set((state) => {
       const pieces = [...state.pieces, piece]
-      return { pieces, coordinateIndex: buildIndex(pieces) }
+      return {
+        pieces,
+        coordinateIndex: buildIndex(pieces),
+        _history: pushHistory(state._history, state.pieces),
+        _future: [],
+      }
     })
   },
 
   removePiece(id) {
     set((state) => {
       const pieces = state.pieces.filter((p) => p.id !== id)
-      return { pieces, coordinateIndex: buildIndex(pieces) }
+      return {
+        pieces,
+        coordinateIndex: buildIndex(pieces),
+        _history: pushHistory(state._history, state.pieces),
+        _future: [],
+      }
     })
   },
 
@@ -62,14 +88,47 @@ export const useStore = create<AppStore>((set) => ({
   },
 
   clearAll() {
-    set({ pieces: [], coordinateIndex: new Map() })
+    set((state) => ({
+      pieces: [],
+      coordinateIndex: new Map(),
+      _history: pushHistory(state._history, state.pieces),
+      _future: [],
+    }))
   },
 
   loadPieces(pieces) {
-    set({ pieces, coordinateIndex: buildIndex(pieces) })
+    set({ pieces, coordinateIndex: buildIndex(pieces), _history: [], _future: [] })
   },
 
   setCameraResetFn(fn) {
     set({ cameraResetFn: fn })
+  },
+
+  undo() {
+    set((state) => {
+      if (state._history.length === 0) return state
+      const history = [...state._history]
+      const previous = history.pop()!
+      return {
+        pieces: previous,
+        coordinateIndex: buildIndex(previous),
+        _history: history,
+        _future: [state.pieces, ...state._future],
+      }
+    })
+  },
+
+  redo() {
+    set((state) => {
+      if (state._future.length === 0) return state
+      const future = [...state._future]
+      const next = future.shift()!
+      return {
+        pieces: next,
+        coordinateIndex: buildIndex(next),
+        _history: [...state._history, state.pieces],
+        _future: future,
+      }
+    })
   },
 }))

--- a/test/store.test.ts
+++ b/test/store.test.ts
@@ -125,3 +125,66 @@ describe('setVisibleLevels', () => {
     expect(useStore.getState().visibleLevels).toEqual(new Set([0, 2]))
   })
 })
+
+describe('undo / redo', () => {
+  it('undo reverts placePiece', () => {
+    act(() => useStore.getState().placePiece('square_hull', { x: 0, y: 0, z: 0 }, 0))
+    expect(useStore.getState().pieces).toHaveLength(1)
+    act(() => useStore.getState().undo())
+    expect(useStore.getState().pieces).toHaveLength(0)
+  })
+
+  it('redo restores undone placePiece', () => {
+    act(() => useStore.getState().placePiece('square_hull', { x: 0, y: 0, z: 0 }, 0))
+    act(() => useStore.getState().undo())
+    act(() => useStore.getState().redo())
+    expect(useStore.getState().pieces).toHaveLength(1)
+  })
+
+  it('undo reverts removePiece', () => {
+    act(() => useStore.getState().placePiece('square_hull', { x: 0, y: 0, z: 0 }, 0))
+    const id = useStore.getState().pieces[0].id
+    act(() => useStore.getState().removePiece(id))
+    expect(useStore.getState().pieces).toHaveLength(0)
+    act(() => useStore.getState().undo())
+    expect(useStore.getState().pieces).toHaveLength(1)
+  })
+
+  it('undo reverts clearAll', () => {
+    act(() => {
+      useStore.getState().placePiece('square_hull', { x: 0, y: 0, z: 0 }, 0)
+      useStore.getState().placePiece('square_hull', { x: 1, y: 0, z: 0 }, 0)
+    })
+    act(() => useStore.getState().clearAll())
+    expect(useStore.getState().pieces).toHaveLength(0)
+    act(() => useStore.getState().undo())
+    expect(useStore.getState().pieces).toHaveLength(2)
+  })
+
+  it('new action clears future', () => {
+    act(() => useStore.getState().placePiece('square_hull', { x: 0, y: 0, z: 0 }, 0))
+    act(() => useStore.getState().undo())
+    act(() => useStore.getState().placePiece('square_hull', { x: 1, y: 0, z: 0 }, 0))
+    act(() => useStore.getState().redo())
+    // redo should be a no-op since future was cleared
+    expect(useStore.getState().pieces).toHaveLength(1)
+  })
+
+  it('undo on empty history is a no-op', () => {
+    // loadPieces resets history, so undo should do nothing
+    act(() => useStore.getState().loadPieces([]))
+    act(() => useStore.getState().undo())
+    expect(useStore.getState().pieces).toHaveLength(0)
+  })
+
+  it('redo on empty future is a no-op', () => {
+    act(() => useStore.getState().redo())
+    expect(useStore.getState().pieces).toHaveLength(0)
+  })
+
+  it('rebuilds coordinateIndex on undo', () => {
+    act(() => useStore.getState().placePiece('square_hull', { x: 0, y: 0, z: 0 }, 0))
+    act(() => useStore.getState().undo())
+    expect(useStore.getState().coordinateIndex.size).toBe(0)
+  })
+})


### PR DESCRIPTION
## Summary
- Undo/redo history stack in the Zustand store (max 50 entries)
- `placePiece`, `removePiece`, and `clearAll` push to history and clear future
- `loadPieces` resets history (fresh start for loaded builds)
- Keyboard shortcuts: Ctrl+Z (undo), Ctrl+Y or Ctrl+Shift+Z (redo)
- 8 new tests covering undo, redo, future clearing, and edge cases

## Test plan
- [ ] Place a few pieces, press Ctrl+Z — last piece should disappear
- [ ] Press Ctrl+Y — piece should reappear
- [ ] Delete a piece, Ctrl+Z — piece should be restored
- [ ] Clear all, Ctrl+Z — all pieces should be restored
- [ ] `npm test` — 60 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)