### PR TITLE
feat(#13): snap squares to triangle edges + fix deploy (#14)

### DIFF
--- a/src/scene/CellMesh.tsx
+++ b/src/scene/CellMesh.tsx
@@ -13,7 +13,7 @@ interface CellMeshProps {
   angleDeg?: number  // for triangle slot rotation (0, 60, 120, 180, 240, 300)
 }
 
-export default function CellMesh({ type, color, opacity = 1, roughness = 0.85, rotation = 0, angleDeg }: CellMeshProps) {
+export default function CellMesh({ type, color, opacity = 1, roughness = 0.85, angleDeg }: CellMeshProps) {
   const transparent = opacity < 1
   const mat = { color, opacity, transparent, roughness }
 

--- a/src/scene/HitPlane.tsx
+++ b/src/scene/HitPlane.tsx
@@ -1,17 +1,17 @@
 import { useState } from 'react'
 import type { ThreeEvent } from '@react-three/fiber'
 import { useStore } from '../store/useStore'
-import { canPlace, canPlaceTriSnap, canPlaceTriSnapEdge } from '../utils/validation'
-import { detectSide } from './pieceGeometry'
+import { canPlace, canPlaceTriSnap, canPlaceTriSnapEdge, canPlaceSquareSnap, canPlaceSquareSnapEdge } from '../utils/validation'
+import { detectSide, getCellPieceShape } from './pieceGeometry'
 import piecesConfig from '../data/pieces-config.json'
 import type { PiecesConfig, XYZ, PieceSide, PieceRotation, PlacedPiece } from '../types'
 import GhostPiece from './GhostPiece'
-import { worldToTriCoord, triSlotWorldPosition, triSlotRotationDeg, triEdgeWorldPosition, triEdgeRotationDeg, detectTriEdge, squareEdgeSnapPosition, triSnapNeighbors, triSnapEdgeWorldPosition, triSnapEdgeRotationDeg, detectTriSnapEdge, HEX_ORIGIN } from '../utils/hexGrid'
-import { toKey, toTriKey, toTriSnapKey, toTriSnapEdgeKey } from '../utils/coordinateKey'
+import { worldToTriCoord, triSlotWorldPosition, triSlotRotationDeg, triEdgeWorldPosition, triEdgeRotationDeg, detectTriEdge, squareEdgeSnapPosition, triSnapNeighbors, triSnapEdgeWorldPosition, triSnapEdgeRotationDeg, detectTriSnapEdge, triEdgeSquareSnapPosition, triSnapEdgeSquareSnapPosition, squareSnapEdgeWorldPosition, squareSnapEdgeRotationDeg, detectSquareSnapSide, HEX_ORIGIN } from '../utils/hexGrid'
+import { toKey, toTriKey, toTriSnapKey, toSquareSnapKey } from '../utils/coordinateKey'
 import { PIECE_COLORS, DEFAULT_COLOR } from './pieceGeometry'
 import CellMesh from './CellMesh'
 import EdgeMesh from './EdgeMesh'
-import type { TriCoord, TriEdgeIndex, TriSnapTarget } from '../types'
+import type { TriCoord, TriEdgeIndex, TriSnapTarget, SquareSnapTarget } from '../types'
 
 const config = piecesConfig as PiecesConfig
 const GRID_W = 5
@@ -117,12 +117,27 @@ interface SnapEdgeResult {
   y: number
 }
 
+interface SquareSnapResult {
+  worldX: number
+  worldZ: number
+  rotDeg: number
+  y: number
+}
+
+interface SquareSnapEdgeResult {
+  parentSnap: SquareSnapTarget
+  side: PieceSide
+  y: number
+}
+
 interface TriGhostState {
   triCoord: TriCoord
   y: number
   triEdge?: TriEdgeIndex
   snap?: SnapResult
   snapEdge?: SnapEdgeResult
+  squareSnap?: SquareSnapResult
+  squareSnapEdge?: SquareSnapEdgeResult
 }
 
 const SNAP_THRESHOLD = 0.5
@@ -232,6 +247,85 @@ function findSnapTriForEdge(
   return best
 }
 
+/** Find the nearest triangle edge to snap a square to. Scans both hex-grid and snap-placed triangles. */
+function findTriEdgeForSquareSnap(
+  wx: number, wz: number, y: number,
+  pieces: PlacedPiece[],
+  coordinateIndex: Map<string, string>,
+): SquareSnapResult | null {
+  let bestDist = SNAP_THRESHOLD
+  let best: SquareSnapResult | null = null
+
+  for (const piece of pieces) {
+    if (piece.position.y !== y) continue
+
+    // Hex-grid triangles
+    if (piece.triCoord && piece.triEdge === undefined && !piece.triSnap) {
+      const { hq, hr, slot } = piece.triCoord
+      for (let e = 0; e < 3; e++) {
+        const mid = triEdgeWorldPosition(hq, 0, hr, slot, e)
+        const dist = Math.sqrt((wx - mid.x) ** 2 + (wz - mid.z) ** 2)
+        if (dist < bestDist) {
+          const snap = triEdgeSquareSnapPosition(hq, hr, slot, e)
+          const snapKey = toSquareSnapKey(snap.worldX, y, snap.worldZ)
+          if (!coordinateIndex.has(snapKey)) {
+            bestDist = dist
+            best = { ...snap, y }
+          }
+        }
+      }
+    }
+
+    // Snap-placed triangles
+    if (piece.triSnap && piece.triEdge === undefined) {
+      const { worldX, worldZ, angleDeg } = piece.triSnap
+      const dx = wx - worldX
+      const dz = wz - worldZ
+      if (dx * dx + dz * dz > 4) continue
+      for (let e = 0; e < 3; e++) {
+        const mid = triSnapEdgeWorldPosition(worldX, worldZ, angleDeg, 0, e)
+        const dist = Math.sqrt((wx - mid.x) ** 2 + (wz - mid.z) ** 2)
+        if (dist < bestDist) {
+          const snap = triSnapEdgeSquareSnapPosition(worldX, worldZ, angleDeg, e)
+          const snapKey = toSquareSnapKey(snap.worldX, y, snap.worldZ)
+          if (!coordinateIndex.has(snapKey)) {
+            bestDist = dist
+            best = { ...snap, y }
+          }
+        }
+      }
+    }
+  }
+
+  return best
+}
+
+/** Find the nearest snap-placed square whose edge the cursor is near (for edge piece placement). */
+function findSquareSnapForEdge(
+  wx: number, wz: number, y: number,
+  pieces: PlacedPiece[],
+): SquareSnapEdgeResult | null {
+  let bestDist = SNAP_THRESHOLD
+  let best: SquareSnapEdgeResult | null = null
+
+  for (const piece of pieces) {
+    if (!piece.squareSnap || piece.side || piece.position.y !== y) continue
+    const { worldX, worldZ, rotDeg } = piece.squareSnap
+    const dx = wx - worldX
+    const dz = wz - worldZ
+    if (dx * dx + dz * dz > 4) continue
+    const side = detectSquareSnapSide(worldX, worldZ, rotDeg, wx, wz)
+    const ep = squareSnapEdgeWorldPosition(worldX, worldZ, rotDeg, y, side)
+    const dist = Math.sqrt((wx - ep.x) ** 2 + (wz - ep.z) ** 2)
+    if (dist < bestDist) {
+      bestDist = dist
+      best = { parentSnap: piece.squareSnap, side, y }
+    }
+  }
+
+  return best
+}
+
 export function TriHitPlane({ floorY }: HitPlaneProps) {
   const selectedPieceType = useStore((s) => s.selectedPieceType)
   const pieces = useStore((s) => s.pieces)
@@ -240,6 +334,8 @@ export function TriHitPlane({ floorY }: HitPlaneProps) {
   const placeTriangleEdgePiece = useStore((s) => s.placeTriangleEdgePiece)
   const placeTriangleSnapped = useStore((s) => s.placeTriangleSnapped)
   const placeTriSnapEdgePiece = useStore((s) => s.placeTriSnapEdgePiece)
+  const placeSquareSnapped = useStore((s) => s.placeSquareSnapped)
+  const placeSquareSnapEdgePiece = useStore((s) => s.placeSquareSnapEdgePiece)
   const [ghost, setGhost] = useState<TriGhostState | null>(null)
 
   if (!selectedPieceType) return null
@@ -249,13 +345,29 @@ export function TriHitPlane({ floorY }: HitPlaneProps) {
 
   const isTriType = selectedPieceType.includes('triangle')
   const isEdgeType = pieceConfig.placementType === 'edge'
+  // Square cell types that can snap to triangle edges (hulls, floors)
+  const isSquareSnapType = pieceConfig.placementType === 'cell' && !isTriType
+    && (pieceConfig.category === 'hull' || pieceConfig.category === 'floor')
 
-  // This hit plane handles: triangle cell pieces, OR edge pieces on triangle foundations
-  if (!isTriType && !isEdgeType) return null
+  // This hit plane handles: triangle cells, edge pieces on triangles/snapped-squares, square cells snapping to triangles
+  if (!isTriType && !isEdgeType && !isSquareSnapType) return null
   // Triangle edge piece types don't exist — skip
   if (isTriType && isEdgeType) return null
 
   function handlePointerMove(e: ThreeEvent<PointerEvent>) {
+    // Square cell snapping to triangle edges
+    if (isSquareSnapType) {
+      const sqSnap = findTriEdgeForSquareSnap(e.point.x, e.point.z, floorY, pieces, coordinateIndex)
+      if (sqSnap) {
+        e.stopPropagation()
+        const triCoord: TriCoord = { hq: 0, hr: 0, slot: 0 }
+        setGhost({ triCoord, y: floorY, squareSnap: sqSnap })
+      } else {
+        setGhost(null)
+      }
+      return
+    }
+
     if (isEdgeType) {
       // Check hex-grid triangles
       const { hq, hr, slot } = worldToTriCoord(e.point.x, e.point.z)
@@ -275,7 +387,15 @@ export function TriHitPlane({ floorY }: HitPlaneProps) {
         setGhost({ triCoord: triCoord2, y: floorY, snapEdge: se })
         return
       }
-      // No triangle found — let event pass through to square HitPlane
+      // Check snap-placed squares
+      const sqse = findSquareSnapForEdge(e.point.x, e.point.z, floorY, pieces)
+      if (sqse) {
+        e.stopPropagation()
+        const triCoord3: TriCoord = { hq: 0, hr: 0, slot: 0 }
+        setGhost({ triCoord: triCoord3, y: floorY, squareSnapEdge: sqse })
+        return
+      }
+      // No triangle/square found — let event pass through to square HitPlane
       setGhost(null)
       return
     }
@@ -301,6 +421,18 @@ export function TriHitPlane({ floorY }: HitPlaneProps) {
   }
 
   function handleClick(e: ThreeEvent<MouseEvent>) {
+    // Square cell snapping to triangle edges
+    if (isSquareSnapType) {
+      const sqSnap = findTriEdgeForSquareSnap(e.point.x, e.point.z, floorY, pieces, coordinateIndex)
+      if (sqSnap) {
+        e.stopPropagation()
+        if (canPlaceSquareSnap(selectedPieceType!, sqSnap, pieces, coordinateIndex, config)) {
+          placeSquareSnapped(selectedPieceType!, sqSnap)
+        }
+      }
+      return
+    }
+
     if (isEdgeType) {
       // Check hex-grid triangles
       const { hq, hr, slot } = worldToTriCoord(e.point.x, e.point.z)
@@ -320,6 +452,15 @@ export function TriHitPlane({ floorY }: HitPlaneProps) {
         e.stopPropagation()
         if (canPlaceTriSnapEdge(selectedPieceType!, se.parentSnap, floorY, se.edge, pieces, coordinateIndex, config)) {
           placeTriSnapEdgePiece(selectedPieceType!, se.parentSnap, floorY, se.edge)
+        }
+        return
+      }
+      // Check snap-placed squares
+      const sqse = findSquareSnapForEdge(e.point.x, e.point.z, floorY, pieces)
+      if (sqse) {
+        e.stopPropagation()
+        if (canPlaceSquareSnapEdge(selectedPieceType!, sqse.parentSnap, floorY, sqse.side, pieces, coordinateIndex, config)) {
+          placeSquareSnapEdgePiece(selectedPieceType!, sqse.parentSnap, floorY, sqse.side)
         }
       }
       return
@@ -349,7 +490,11 @@ export function TriHitPlane({ floorY }: HitPlaneProps) {
   // Compute ghost validity
   let isValid = false
   if (ghost) {
-    if (ghost.snapEdge) {
+    if (ghost.squareSnap) {
+      isValid = canPlaceSquareSnap(selectedPieceType, ghost.squareSnap, pieces, coordinateIndex, config)
+    } else if (ghost.squareSnapEdge) {
+      isValid = canPlaceSquareSnapEdge(selectedPieceType, ghost.squareSnapEdge.parentSnap, ghost.squareSnapEdge.y, ghost.squareSnapEdge.side, pieces, coordinateIndex, config)
+    } else if (ghost.snapEdge) {
       isValid = canPlaceTriSnapEdge(selectedPieceType, ghost.snapEdge.parentSnap, ghost.snapEdge.y, ghost.snapEdge.edge, pieces, coordinateIndex, config)
     } else if (ghost.snap) {
       isValid = canPlaceTriSnap(selectedPieceType, ghost.snap, pieces, coordinateIndex, config)
@@ -363,7 +508,7 @@ export function TriHitPlane({ floorY }: HitPlaneProps) {
   return (
     <>
       <mesh
-        position={[HEX_ORIGIN.x, floorY, HEX_ORIGIN.z]}
+        position={[HEX_ORIGIN.x, floorY + 0.001, HEX_ORIGIN.z]}
         rotation={[-Math.PI / 2, 0, 0]}
         onPointerMove={handlePointerMove}
         onPointerLeave={handlePointerLeave}
@@ -372,6 +517,20 @@ export function TriHitPlane({ floorY }: HitPlaneProps) {
         <planeGeometry args={[planeSize, planeSize]} />
         <meshBasicMaterial visible={false} />
       </mesh>
+      {ghost && ghost.squareSnap && (
+        <SquareSnapGhostPiece
+          type={selectedPieceType}
+          squareSnap={ghost.squareSnap}
+          valid={isValid}
+        />
+      )}
+      {ghost && ghost.squareSnapEdge && (
+        <SquareSnapEdgeGhostPiece
+          type={selectedPieceType}
+          squareSnapEdge={ghost.squareSnapEdge}
+          valid={isValid}
+        />
+      )}
       {ghost && ghost.snap && isTriType && (
         <TriSnapGhostPiece
           type={selectedPieceType}
@@ -458,6 +617,42 @@ function TriSnapEdgeGhostPiece({ type, snapEdge, valid }: {
   const wp = triSnapEdgeWorldPosition(worldX, worldZ, angleDeg, snapEdge.y, snapEdge.edge)
   const rotDeg = triSnapEdgeRotationDeg(worldX, worldZ, angleDeg, snapEdge.edge)
   const rotRad = (rotDeg * Math.PI) / 180
+  const wallH = type.includes('low') || type.includes('barrier') ? 0.33 : 0.95
+
+  return (
+    <group position={[wp.x, wp.y + wallH / 2, wp.z]} rotation={[0, rotRad, 0]}>
+      <EdgeMesh type={type} side="north" color={color} opacity={0.45} roughness={0.85} />
+    </group>
+  )
+}
+
+function SquareSnapGhostPiece({ type, squareSnap, valid }: {
+  type: string; squareSnap: SquareSnapResult; valid: boolean
+}) {
+  const baseColor = PIECE_COLORS[type] ?? DEFAULT_COLOR
+  const color = valid ? baseColor : '#ff3333'
+  const shape = getCellPieceShape(type)
+  const rotRad = (squareSnap.rotDeg * Math.PI) / 180
+
+  return (
+    <group
+      position={[squareSnap.worldX, squareSnap.y + shape.offset[1], squareSnap.worldZ]}
+      rotation={[0, rotRad, 0]}
+    >
+      <CellMesh type={type} color={color} opacity={0.45} roughness={0.85} />
+    </group>
+  )
+}
+
+function SquareSnapEdgeGhostPiece({ type, squareSnapEdge, valid }: {
+  type: string; squareSnapEdge: SquareSnapEdgeResult; valid: boolean
+}) {
+  const baseColor = PIECE_COLORS[type] ?? DEFAULT_COLOR
+  const color = valid ? baseColor : '#ff3333'
+  const { worldX, worldZ, rotDeg } = squareSnapEdge.parentSnap
+  const wp = squareSnapEdgeWorldPosition(worldX, worldZ, rotDeg, squareSnapEdge.y, squareSnapEdge.side)
+  const edgeRotDeg = squareSnapEdgeRotationDeg(rotDeg, squareSnapEdge.side)
+  const rotRad = (edgeRotDeg * Math.PI) / 180
   const wallH = type.includes('low') || type.includes('barrier') ? 0.33 : 0.95
 
   return (

--- a/src/scene/PlacedPieces.tsx
+++ b/src/scene/PlacedPieces.tsx
@@ -1,8 +1,8 @@
 import { useStore } from '../store/useStore'
-import { PIECE_COLORS, DEFAULT_COLOR, getPiecePosition, isTriangleType } from './pieceGeometry'
+import { PIECE_COLORS, DEFAULT_COLOR, getPiecePosition, isTriangleType, getCellPieceShape } from './pieceGeometry'
 import EdgeMesh from './EdgeMesh'
 import CellMesh from './CellMesh'
-import { triSlotWorldPosition, triSlotRotationDeg, triEdgeWorldPosition, triEdgeRotationDeg, triSnapEdgeWorldPosition, triSnapEdgeRotationDeg } from '../utils/hexGrid'
+import { triSlotWorldPosition, triSlotRotationDeg, triEdgeWorldPosition, triEdgeRotationDeg, triSnapEdgeWorldPosition, triSnapEdgeRotationDeg, squareSnapEdgeWorldPosition, squareSnapEdgeRotationDeg } from '../utils/hexGrid'
 
 export default function PlacedPieces() {
   const pieces = useStore((s) => s.pieces)
@@ -30,6 +30,51 @@ export default function PlacedPieces() {
             e.stopPropagation()
             selectPiece(isSelected ? null : piece.id)
           }
+        }
+
+        // Edge pieces on snap-placed squares
+        if (piece.squareSnap && piece.side) {
+          const { worldX, worldZ, rotDeg } = piece.squareSnap
+          const wp = squareSnapEdgeWorldPosition(worldX, worldZ, rotDeg, piece.position.y, piece.side)
+          const edgeRotDeg = squareSnapEdgeRotationDeg(rotDeg, piece.side)
+          const rotRad = (edgeRotDeg * Math.PI) / 180
+          const wallH = piece.type.includes('low') || piece.type.includes('barrier') ? 0.33 : 0.95
+          return (
+            <group
+              key={piece.id}
+              position={[wp.x, wp.y + wallH / 2, wp.z]}
+              rotation={[0, rotRad, 0]}
+              onClick={handleClick}
+            >
+              <EdgeMesh
+                type={piece.type}
+                side="north"
+                color={color}
+                opacity={isSelectMode ? 0.8 : 1}
+              />
+            </group>
+          )
+        }
+
+        // Squares snapped to a triangle edge
+        if (piece.squareSnap) {
+          const { worldX, worldZ, rotDeg } = piece.squareSnap
+          const shape = getCellPieceShape(piece.type)
+          const rotRad = (rotDeg * Math.PI) / 180
+          return (
+            <group
+              key={piece.id}
+              position={[worldX, piece.position.y + shape.offset[1], worldZ]}
+              rotation={[0, rotRad, 0]}
+              onClick={handleClick}
+            >
+              <CellMesh
+                type={piece.type}
+                color={color}
+                opacity={isSelectMode ? 0.8 : 1}
+              />
+            </group>
+          )
         }
 
         // Edge pieces on snap-placed triangles

--- a/src/store/useStore.ts
+++ b/src/store/useStore.ts
@@ -1,6 +1,6 @@
 import { create } from 'zustand'
-import { toKey, toEdgeKey, toTriKey, toTriEdgeKey, toTriSnapKey, toTriSnapEdgeKey } from '../utils/coordinateKey'
-import type { PlacedPiece, XYZ, PieceRotation, PieceSide, TriCoord, TriSnapTarget } from '../types'
+import { toKey, toEdgeKey, toTriKey, toTriEdgeKey, toTriSnapKey, toTriSnapEdgeKey, toSquareSnapKey, toSquareSnapEdgeKey } from '../utils/coordinateKey'
+import type { PlacedPiece, XYZ, PieceRotation, PieceSide, TriCoord, TriSnapTarget, SquareSnapTarget } from '../types'
 
 const MAX_HISTORY = 50
 
@@ -21,6 +21,8 @@ interface AppStore {
   placeTriangleEdgePiece(type: string, y: number, triCoord: TriCoord, triEdge: 0 | 1 | 2): void
   placeTriangleSnapped(type: string, snap: TriSnapTarget & { y: number }): void
   placeTriSnapEdgePiece(type: string, snap: TriSnapTarget, y: number, edge: 0 | 1 | 2): void
+  placeSquareSnapped(type: string, snap: SquareSnapTarget & { y: number }): void
+  placeSquareSnapEdgePiece(type: string, snap: SquareSnapTarget, y: number, side: PieceSide): void
   removePiece(id: string): void
   setVisibleLevels(levels: Set<0 | 1 | 2>): void
   selectPieceType(type: string | null): void
@@ -36,7 +38,19 @@ interface AppStore {
 function buildIndex(pieces: PlacedPiece[]): Map<string, string> {
   const index = new Map<string, string>()
   for (const piece of pieces) {
-    if (piece.triSnap) {
+    if (piece.squareSnap) {
+      if (piece.side) {
+        index.set(
+          toSquareSnapEdgeKey(piece.squareSnap.worldX, piece.position.y, piece.squareSnap.worldZ, piece.side),
+          piece.id,
+        )
+      } else {
+        index.set(
+          toSquareSnapKey(piece.squareSnap.worldX, piece.position.y, piece.squareSnap.worldZ),
+          piece.id,
+        )
+      }
+    } else if (piece.triSnap) {
       if (piece.triEdge !== undefined) {
         index.set(
           toTriSnapEdgeKey(piece.triSnap.worldX, piece.position.y, piece.triSnap.worldZ, piece.triEdge),
@@ -169,6 +183,47 @@ export const useStore = create<AppStore>((set) => ({
       rotation: 0,
       triSnap: snap,
       triEdge: edge,
+    }
+    set((state) => {
+      const pieces = [...state.pieces, piece]
+      return {
+        pieces,
+        coordinateIndex: buildIndex(pieces),
+        _history: pushHistory(state._history, state.pieces),
+        _future: [],
+      }
+    })
+  },
+
+  placeSquareSnapped(type, snap) {
+    const id = crypto.randomUUID()
+    const piece: PlacedPiece = {
+      id,
+      type,
+      position: { x: 0, y: snap.y, z: 0 },
+      rotation: 0,
+      squareSnap: { worldX: snap.worldX, worldZ: snap.worldZ, rotDeg: snap.rotDeg },
+    }
+    set((state) => {
+      const pieces = [...state.pieces, piece]
+      return {
+        pieces,
+        coordinateIndex: buildIndex(pieces),
+        _history: pushHistory(state._history, state.pieces),
+        _future: [],
+      }
+    })
+  },
+
+  placeSquareSnapEdgePiece(type, snap, y, side) {
+    const id = crypto.randomUUID()
+    const piece: PlacedPiece = {
+      id,
+      type,
+      position: { x: 0, y, z: 0 },
+      rotation: 0,
+      squareSnap: snap,
+      side,
     }
     set((state) => {
       const pieces = [...state.pieces, piece]

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -26,6 +26,12 @@ export interface TriSnapTarget {
   angleDeg: number
 }
 
+export interface SquareSnapTarget {
+  worldX: number
+  worldZ: number
+  rotDeg: number
+}
+
 export interface PlacedPiece {
   id: string
   type: string
@@ -35,6 +41,7 @@ export interface PlacedPiece {
   triCoord?: TriCoord
   triEdge?: TriEdgeIndex
   triSnap?: TriSnapTarget // triangle snapped to a square edge
+  squareSnap?: SquareSnapTarget // square snapped to a triangle edge
 }
 
 export type FloorConstraint = 'ground_only' | 'upper_only' | null

--- a/src/utils/coordinateKey.ts
+++ b/src/utils/coordinateKey.ts
@@ -21,6 +21,12 @@ export const toTriSnapKey = (worldX: number, y: number, worldZ: number): string 
 export const toTriSnapEdgeKey = (worldX: number, y: number, worldZ: number, edge: number): string =>
   `tsnapedge:${Math.round(worldX * 1000)},${y},${Math.round(worldZ * 1000)},${edge}`
 
+export const toSquareSnapKey = (worldX: number, y: number, worldZ: number): string =>
+  `sqsnap:${Math.round(worldX * 1000)},${y},${Math.round(worldZ * 1000)}`
+
+export const toSquareSnapEdgeKey = (worldX: number, y: number, worldZ: number, side: string): string =>
+  `sqsnapedge:${Math.round(worldX * 1000)},${y},${Math.round(worldZ * 1000)},${side}`
+
 export function parseTriKey(key: string): { hq: number; y: number; hr: number; slot: number } | null {
   if (!key.startsWith('t:')) return null
   if (key.startsWith('te:')) return null

--- a/src/utils/hexGrid.ts
+++ b/src/utils/hexGrid.ts
@@ -326,6 +326,71 @@ export function triSnapEdgeRotationDeg(worldX: number, worldZ: number, angleDeg:
   return -Math.atan2(dz, dx) * (180 / Math.PI)
 }
 
+/**
+ * Compute the position and rotation for a square snapped to a triangle edge.
+ * The square aligns one edge with the triangle edge and extends outward.
+ *
+ * @param v0 First vertex of the triangle edge
+ * @param v1 Second vertex of the triangle edge
+ * @param centroidX Triangle centroid X (used to determine outward direction)
+ * @param centroidZ Triangle centroid Z
+ */
+function squareSnapFromEdgeVertices(
+  v0: { x: number; z: number },
+  v1: { x: number; z: number },
+  centroidX: number,
+  centroidZ: number,
+): { worldX: number; worldZ: number; rotDeg: number } {
+  const mx = (v0.x + v1.x) / 2
+  const mz = (v0.z + v1.z) / 2
+
+  const dx = v1.x - v0.x
+  const dz = v1.z - v0.z
+  const len = Math.sqrt(dx * dx + dz * dz)
+
+  // Two candidate normals (perpendicular to edge)
+  const n1x = -dz / len
+  const n1z = dx / len
+
+  // Choose outward normal (pointing away from triangle centroid)
+  const toCx = centroidX - mx
+  const toCz = centroidZ - mz
+  const dot = n1x * toCx + n1z * toCz
+  const nx = dot < 0 ? n1x : dz / len
+  const nz = dot < 0 ? n1z : -dx / len
+
+  // Square center = edge midpoint + 0.5 * outward normal
+  const worldX = mx + 0.5 * nx
+  const worldZ = mz + 0.5 * nz
+
+  // Rotate square so one pair of edges aligns with the triangle edge direction
+  const edgeAngleDeg = Math.atan2(dz, dx) * (180 / Math.PI)
+  const rotDeg = -edgeAngleDeg
+
+  return { worldX, worldZ, rotDeg }
+}
+
+/** Square snap position for a hex-grid triangle edge. */
+export function triEdgeSquareSnapPosition(
+  hq: number, hr: number, slot: number, edge: number,
+): { worldX: number; worldZ: number; rotDeg: number } {
+  const verts = triSlotVertices(hq, hr, slot)
+  const v0 = verts[edge]
+  const v1 = verts[(edge + 1) % 3]
+  const c = triSlotWorldPosition(hq, 0, hr, slot)
+  return squareSnapFromEdgeVertices(v0, v1, c.x, c.z)
+}
+
+/** Square snap position for a snap-placed triangle edge. */
+export function triSnapEdgeSquareSnapPosition(
+  parentWorldX: number, parentWorldZ: number, parentAngleDeg: number, edge: number,
+): { worldX: number; worldZ: number; rotDeg: number } {
+  const verts = triSnapVertices(parentWorldX, parentWorldZ, parentAngleDeg)
+  const v0 = verts[edge]
+  const v1 = verts[(edge + 1) % 3]
+  return squareSnapFromEdgeVertices(v0, v1, parentWorldX, parentWorldZ)
+}
+
 /** Detect which edge (0, 1, 2) a world point is closest to on a snap-placed triangle. */
 export function detectTriSnapEdge(
   worldX: number, worldZ: number, angleDeg: number,
@@ -346,4 +411,69 @@ export function detectTriSnapEdge(
     }
   }
   return closest
+}
+
+/**
+ * World position of an edge on a snap-placed square.
+ * Local offsets are rotated by the square's rotDeg.
+ *
+ * Sides in local (unrotated) frame:
+ *   north: (0, -0.5)  south: (0, +0.5)  east: (+0.5, 0)  west: (-0.5, 0)
+ */
+export function squareSnapEdgeWorldPosition(
+  worldX: number, worldZ: number, rotDeg: number, y: number,
+  side: 'north' | 'south' | 'east' | 'west',
+): { x: number; y: number; z: number } {
+  const theta = (rotDeg * Math.PI) / 180
+  let lx: number, lz: number
+  switch (side) {
+    case 'north': lx = 0; lz = -0.5; break
+    case 'east':  lx = 0.5; lz = 0; break
+    case 'south': lx = 0; lz = 0.5; break
+    case 'west':  lx = -0.5; lz = 0; break
+  }
+  return {
+    x: worldX + lx * Math.cos(theta) + lz * Math.sin(theta),
+    y,
+    z: worldZ - lx * Math.sin(theta) + lz * Math.cos(theta),
+  }
+}
+
+/**
+ * Rotation (degrees) for an edge piece on a snap-placed square side.
+ * Returns the Y-rotation so that a "north" EdgeMesh aligns with the side.
+ */
+export function squareSnapEdgeRotationDeg(
+  rotDeg: number,
+  side: 'north' | 'south' | 'east' | 'west',
+): number {
+  switch (side) {
+    case 'north': return rotDeg
+    case 'east':  return rotDeg - 90
+    case 'south': return rotDeg - 180
+    case 'west':  return rotDeg - 270
+  }
+}
+
+/**
+ * Detect which side of a snap-placed square a world point is closest to.
+ * Transforms the point into the square's local frame and picks the nearest edge.
+ */
+export function detectSquareSnapSide(
+  worldX: number, worldZ: number, rotDeg: number,
+  wx: number, wz: number,
+): 'north' | 'south' | 'east' | 'west' {
+  const theta = (rotDeg * Math.PI) / 180
+  const dx = wx - worldX
+  const dz = wz - worldZ
+  // Inverse rotation: local = R(-θ) * world_offset
+  const lx = dx * Math.cos(theta) - dz * Math.sin(theta)
+  const lz = dx * Math.sin(theta) + dz * Math.cos(theta)
+  // Distance to each edge (square spans -0.5 to +0.5 in local frame)
+  const distX = Math.min(Math.abs(lx - 0.5), Math.abs(lx + 0.5))
+  const distZ = Math.min(Math.abs(lz - 0.5), Math.abs(lz + 0.5))
+  if (distX < distZ) {
+    return lx > 0 ? 'east' : 'west'
+  }
+  return lz > 0 ? 'south' : 'north'
 }

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -1,5 +1,5 @@
-import type { XYZ, FloorConstraint, PlacedPiece, PiecesConfig, PieceSide, TriCoord, TriSnapTarget } from '../types'
-import { toKey, toEdgeKey, toTriKey, toTriEdgeKey, toTriSnapKey, toTriSnapEdgeKey } from './coordinateKey'
+import type { XYZ, FloorConstraint, PlacedPiece, PiecesConfig, PieceSide, TriCoord, TriSnapTarget, SquareSnapTarget } from '../types'
+import { toKey, toEdgeKey, toTriKey, toTriEdgeKey, toTriSnapKey, toTriSnapEdgeKey, toSquareSnapKey, toSquareSnapEdgeKey } from './coordinateKey'
 
 const GRID_X = 5
 const GRID_Z = 11
@@ -133,6 +133,44 @@ export function canPlaceTriSnapEdge(
   if (!coordinateIndex.has(foundKey)) return false
   // Must not already have an edge piece here
   const edgeKey = toTriSnapEdgeKey(snap.worldX, y, snap.worldZ, edge)
+  if (coordinateIndex.has(edgeKey)) return false
+  return true
+}
+
+export function canPlaceSquareSnap(
+  type: string,
+  snap: SquareSnapTarget & { y: number },
+  pieces: PlacedPiece[],
+  coordinateIndex: Map<string, string>,
+  config: PiecesConfig,
+): boolean {
+  const pieceConfig = config[type]
+  if (!pieceConfig) return false
+  if (!isFloorAllowed({ x: 0, y: snap.y, z: 0 }, pieceConfig.floorConstraint)) return false
+  if (isMaxCountReached(type, pieces, config)) return false
+  const snapKey = toSquareSnapKey(snap.worldX, snap.y, snap.worldZ)
+  if (coordinateIndex.has(snapKey)) return false
+  return true
+}
+
+export function canPlaceSquareSnapEdge(
+  type: string,
+  snap: SquareSnapTarget,
+  y: number,
+  side: PieceSide,
+  pieces: PlacedPiece[],
+  coordinateIndex: Map<string, string>,
+  config: PiecesConfig,
+): boolean {
+  const pieceConfig = config[type]
+  if (!pieceConfig) return false
+  if (!isFloorAllowed({ x: 0, y, z: 0 }, pieceConfig.floorConstraint)) return false
+  if (isMaxCountReached(type, pieces, config)) return false
+  // Must have a snap-placed square foundation at this position
+  const foundKey = toSquareSnapKey(snap.worldX, y, snap.worldZ)
+  if (!coordinateIndex.has(foundKey)) return false
+  // Must not already have an edge piece here
+  const edgeKey = toSquareSnapEdgeKey(snap.worldX, y, snap.worldZ, side)
   if (coordinateIndex.has(edgeKey)) return false
   return true
 }


### PR DESCRIPTION
## Summary
- Square hull/floor pieces snap to any triangle edge (hex-grid or snap-placed), rendering rotated to align flush
- Edge pieces (doorways, walls, windows) can be placed on snapped square sides
- Fixes #14: removes unused imports (`toTriSnapEdgeKey`, `rotation` destructure) that broke the GitHub Pages deploy

## Changes
- **types/index.ts** — `SquareSnapTarget` type, `squareSnap` field on `PlacedPiece`
- **hexGrid.ts** — square snap position from triangle edges, edge position/rotation/detection on snapped squares
- **coordinateKey.ts** — `toSquareSnapKey`, `toSquareSnapEdgeKey`
- **validation.ts** — `canPlaceSquareSnap`, `canPlaceSquareSnapEdge`
- **useStore.ts** — `placeSquareSnapped`, `placeSquareSnapEdgePiece` actions, `buildIndex` updated
- **HitPlane.tsx** — TriHitPlane handles square cell types, snap detection for squares and edge pieces on snapped squares
- **PlacedPieces.tsx** — rendering for snapped squares and edge pieces on them
- **CellMesh.tsx** — removed unused `rotation` destructure

## Test plan
- [x] `tsc --noEmit` passes
- [x] `vitest run` — 107 tests pass
- [x] Place triangle hull, then snap square hull to its edge — square aligns flush
- [x] Place doorway on snapped square's edges
- [x] Normal grid placement still works without interference
- [x] Deploy-breaking unused imports removed

Closes #13, closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)