### PR TITLE
fix: resolve open issues #17 and #18

### DIFF
--- a/src/scene/CellMesh.tsx
+++ b/src/scene/CellMesh.tsx
@@ -19,9 +19,17 @@ export default function CellMesh({ type, color, opacity = 1, roughness = 0.7, an
   const woodTex = getWoodTexture()
   const mat = { color, opacity, transparent, roughness, metalness: 0.05, map: woodTex }
 
-  if (type === 'triangle_hull' || type === 'floor_triangle' || type === 'floor_frame_triangle') {
+  if (type === 'triangle_hull' || type === 'floor_triangle') {
     const h = type === 'triangle_hull' ? 0.15 : 0.1
     return <TrianglePrism height={h} mat={mat} angleDeg={angleDeg ?? 210} />
+  }
+
+  if (type === 'floor_frame_triangle') {
+    return <TriangleFramePrism height={0.1} mat={mat} angleDeg={angleDeg ?? 210} />
+  }
+
+  if (type === 'floor_frame_square') {
+    return <SquareFloorFrame mat={mat} />
   }
 
   const shape = getCellPieceShape(type)
@@ -122,6 +130,72 @@ function TrianglePrism({ height, mat, angleDeg }: { height: number; mat: MatProp
     geo.setAttribute('position', new THREE.Float32BufferAttribute(positions, 3))
     geo.setAttribute('uv', new THREE.Float32BufferAttribute(uvs, 2))
     geo.computeVertexNormals()
+    return geo
+  }, [height, angleDeg])
+
+  return (
+    <mesh geometry={geometry}>
+      <meshStandardMaterial {...mat} side={THREE.DoubleSide} />
+    </mesh>
+  )
+}
+
+/**
+ * Square floor frame — 4 border strips forming a rectangular cutout.
+ */
+function SquareFloorFrame({ mat }: { mat: MatProps }) {
+  const FRAME_T = 0.12
+  const H = 0.1
+  const inner = 1 - 2 * FRAME_T
+
+  const strips: { size: [number, number, number]; pos: [number, number, number] }[] = [
+    { size: [1, H, FRAME_T], pos: [0, 0, -(0.5 - FRAME_T / 2)] },
+    { size: [1, H, FRAME_T], pos: [0, 0, 0.5 - FRAME_T / 2] },
+    { size: [FRAME_T, H, inner], pos: [-(0.5 - FRAME_T / 2), 0, 0] },
+    { size: [FRAME_T, H, inner], pos: [0.5 - FRAME_T / 2, 0, 0] },
+  ]
+
+  return (
+    <group>
+      {strips.map((s, i) => (
+        <mesh key={i} position={s.pos}>
+          <boxGeometry args={s.size} />
+          <meshStandardMaterial {...mat} />
+        </mesh>
+      ))}
+    </group>
+  )
+}
+
+/**
+ * Triangle floor frame — outer triangle with inner cutout using ExtrudeGeometry.
+ */
+function TriangleFramePrism({ height, mat, angleDeg }: { height: number; mat: MatProps; angleDeg: number }) {
+  const geometry = useMemo(() => {
+    const verts = getEquilateralVertices(angleDeg)
+    const [a, b, c] = verts
+
+    // Outer triangle shape (XY plane, Y maps to world Z)
+    const shape = new THREE.Shape()
+    shape.moveTo(a[0], a[1])
+    shape.lineTo(b[0], b[1])
+    shape.lineTo(c[0], c[1])
+    shape.closePath()
+
+    // Inner triangle scaled toward centroid
+    const cx = (a[0] + b[0] + c[0]) / 3
+    const cy = (a[1] + b[1] + c[1]) / 3
+    const s = 0.55
+    const hole = new THREE.Path()
+    hole.moveTo(cx + (a[0] - cx) * s, cy + (a[1] - cy) * s)
+    hole.lineTo(cx + (b[0] - cx) * s, cy + (b[1] - cy) * s)
+    hole.lineTo(cx + (c[0] - cx) * s, cy + (c[1] - cy) * s)
+    hole.closePath()
+    shape.holes.push(hole)
+
+    const geo = new THREE.ExtrudeGeometry(shape, { depth: height, bevelEnabled: false })
+    // Rotate so extrusion goes along Y (up) instead of Z
+    geo.rotateX(-Math.PI / 2)
     return geo
   }, [height, angleDeg])
 

--- a/src/scene/HitPlane.tsx
+++ b/src/scene/HitPlane.tsx
@@ -68,6 +68,7 @@ export default function HitPlane({ floorY }: HitPlaneProps) {
   }
 
   function handleClick(e: ThreeEvent<MouseEvent>) {
+    if (e.delta > 5) return
     e.stopPropagation()
     const state = toGhostState(e.point)
     if (canPlace(selectedPieceType!, state.pos, pieces, coordinateIndex, config, state.side)) {
@@ -421,6 +422,7 @@ export function TriHitPlane({ floorY }: HitPlaneProps) {
   }
 
   function handleClick(e: ThreeEvent<MouseEvent>) {
+    if (e.delta > 5) return
     // Square cell snapping to triangle edges
     if (isSquareSnapType) {
       const sqSnap = findTriEdgeForSquareSnap(e.point.x, e.point.z, floorY, pieces, coordinateIndex)


### PR DESCRIPTION
## Summary

- **Fixes #17**: Prevents accidental piece placement when releasing the mouse after rotating the camera. Uses R3F's `e.delta` property to detect drag vs click — if the pointer moved more than 5 pixels between press and release, the click is treated as a camera rotation and no piece is placed.
- **Fixes #18**: Floor frames (`floor_frame_square` and `floor_frame_triangle`) now render as visible cutouts instead of looking identical to regular solid floors:
  - **Square frames**: Rendered as 4 border strips forming a rectangular outline with an open center
  - **Triangle frames**: Rendered using `ExtrudeGeometry` with an inner triangle hole scaled to 55% of the outer triangle, creating a clear frame/cutout appearance

## Test plan

- [ ] Select a piece type, hold mouse button 1 and rotate the camera — releasing should **not** place a piece
- [ ] Click without dragging — piece should still place normally
- [ ] Place a `floor_frame_square` — it should appear as a rectangular border with an open center
- [ ] Place a `floor_frame_triangle` — it should appear as a triangular border with an open center
- [ ] Verify regular `floor_square` and `floor_triangle` still render as solid pieces
- [ ] Test frame placement on all floor levels (1, 2)
- [ ] Test triangle frame rendering at different hex grid positions/rotations

https://claude.ai/code/session_01DWUPr1uyjsSDpW4iy4U9fN