### PR TITLE
feat(#21,#22): wall stacking, floor snapping, and wall variant models

### DIFF
--- a/src/scene/EdgeMesh.tsx
+++ b/src/scene/EdgeMesh.tsx
@@ -35,8 +35,18 @@ export default function EdgeMesh({ type, side, color, opacity = 1, roughness = 0
   const woodTex = getWoodTexture()
   const mat = { color, opacity, transparent, roughness, metalness: 0.05, map: woodTex }
 
+  // Cannon wall — short wall with center cutout for cannon barrel
+  if (type === 'low_cannon_wall') {
+    return <CannonWall isNS={isNS} mat={mat} />
+  }
+
+  // Low barrier — fence-style with horizontal planks and gaps
+  if (type === 'low_wall_barrier') {
+    return <FenceBarrier isNS={isNS} mat={mat} />
+  }
+
   // Low walls — simple short box
-  if (type.includes('low') || type.includes('barrier')) {
+  if (type.includes('low')) {
     const h = 0.33
     const size: [number, number, number] = isNS
       ? [WALL_W, h, THICKNESS]
@@ -199,6 +209,91 @@ function StairsMesh({ side, mat }: { side: PieceSide; mat: FrameProps['mat'] }) 
           </mesh>
         )
       })}
+    </group>
+  )
+}
+
+/**
+ * Cannon wall: short wall (0.33) with a rectangular cutout in the center
+ * for a cannon barrel to poke through.
+ */
+function CannonWall({ isNS, mat }: FrameProps) {
+  const H = 0.33
+  const openW = 0.22
+  const sideW = (WALL_W - openW) / 2
+
+  // 3 pieces: bottom strip + two side pillars (cutout open to the top)
+  const botH = 0.14
+  const pillarH = H - botH
+  const botY = -(H - botH) / 2
+  const pillarY = (H - pillarH) / 2
+
+  const parts: { size: [number, number, number]; pos: [number, number, number] }[] = isNS
+    ? [
+        { size: [WALL_W, botH, THICKNESS], pos: [0, botY, 0] },
+        { size: [sideW, pillarH, THICKNESS], pos: [-(openW + sideW) / 2, pillarY, 0] },
+        { size: [sideW, pillarH, THICKNESS], pos: [(openW + sideW) / 2, pillarY, 0] },
+      ]
+    : [
+        { size: [THICKNESS, botH, WALL_W], pos: [0, botY, 0] },
+        { size: [THICKNESS, pillarH, sideW], pos: [0, pillarY, -(openW + sideW) / 2] },
+        { size: [THICKNESS, pillarH, sideW], pos: [0, pillarY, (openW + sideW) / 2] },
+      ]
+
+  return (
+    <group>
+      {parts.map((p, i) => (
+        <mesh key={i} position={p.pos}>
+          <boxGeometry args={p.size} />
+          <meshStandardMaterial {...mat} />
+        </mesh>
+      ))}
+    </group>
+  )
+}
+
+/**
+ * Fence barrier: horizontal planks with gaps between them, two end posts.
+ */
+function FenceBarrier({ isNS, mat }: FrameProps) {
+  const H = 0.33
+  const postW = 0.06
+  const plankH = 0.055
+  const gap = 0.035
+  const plankW = WALL_W - postW * 2
+  // 3 planks + 2 gaps + top/bottom margins
+  const plankYs = [
+    -(H / 2) + plankH / 2 + 0.02,
+    0,
+    (H / 2) - plankH / 2 - 0.02,
+  ]
+
+  const meshes: { size: [number, number, number]; pos: [number, number, number] }[] = []
+
+  // End posts
+  const postOffset = (WALL_W - postW) / 2
+  if (isNS) {
+    meshes.push({ size: [postW, H, THICKNESS], pos: [-postOffset, 0, 0] })
+    meshes.push({ size: [postW, H, THICKNESS], pos: [postOffset, 0, 0] })
+    for (const py of plankYs) {
+      meshes.push({ size: [plankW, plankH, THICKNESS], pos: [0, py, 0] })
+    }
+  } else {
+    meshes.push({ size: [THICKNESS, H, postW], pos: [0, 0, -postOffset] })
+    meshes.push({ size: [THICKNESS, H, postW], pos: [0, 0, postOffset] })
+    for (const py of plankYs) {
+      meshes.push({ size: [THICKNESS, plankH, plankW], pos: [0, py, 0] })
+    }
+  }
+
+  return (
+    <group>
+      {meshes.map((m, i) => (
+        <mesh key={i} position={m.pos}>
+          <boxGeometry args={m.size} />
+          <meshStandardMaterial {...mat} />
+        </mesh>
+      ))}
     </group>
   )
 }

--- a/src/scene/HitPlane.tsx
+++ b/src/scene/HitPlane.tsx
@@ -446,14 +446,14 @@ function findSquareSnapForEdge(
   return best
 }
 
-/** Given multiple snap candidates, return the one closest to the cursor. */
+/** Given multiple snap candidates, return the one closest to the cursor (prefer higher y on tie). */
 function pickClosestSnap(candidates: (SnapResult | null)[], wx: number, wz: number): SnapResult | null {
   let best: SnapResult | null = null
   let bestDist = Infinity
   for (const c of candidates) {
     if (!c) continue
     const dist = (wx - c.worldX) ** 2 + (wz - c.worldZ) ** 2
-    if (dist < bestDist) {
+    if (dist < bestDist || (dist === bestDist && best && c.y > best.y)) {
       bestDist = dist
       best = c
     }
@@ -467,7 +467,7 @@ function pickClosestSquareSnap(candidates: (SquareSnapResult | null)[], wx: numb
   for (const c of candidates) {
     if (!c) continue
     const dist = (wx - c.worldX) ** 2 + (wz - c.worldZ) ** 2
-    if (dist < bestDist) {
+    if (dist < bestDist || (dist === bestDist && best && c.y > best.y)) {
       bestDist = dist
       best = c
     }
@@ -475,47 +475,47 @@ function pickClosestSquareSnap(candidates: (SquareSnapResult | null)[], wx: numb
   return best
 }
 
-/** Collect snap results from both the target floor and the floor below, overriding y to targetY. */
+/** Collect snap results across all target floors (same-level + floor-below support). */
 function collectFloorSnaps(
-  wx: number, wz: number, targetY: number,
+  wx: number, wz: number, floors: number[],
   pieces: PlacedPiece[], coordinateIndex: Map<string, string>,
 ): SnapResult[] {
-  const results: (SnapResult | null)[] = [
-    findSquareEdgeSnap(wx, wz, targetY, coordinateIndex),
-    findSnappedSquareEdgeSnap(wx, wz, targetY, pieces, coordinateIndex),
-    findTriEdgeSnap(wx, wz, targetY, pieces, coordinateIndex),
-  ]
-  if (targetY > 0) {
-    const below = [
-      findSquareEdgeSnap(wx, wz, targetY - 1, coordinateIndex),
-      findSnappedSquareEdgeSnap(wx, wz, targetY - 1, pieces, coordinateIndex),
-      findTriEdgeSnap(wx, wz, targetY - 1, pieces, coordinateIndex),
-    ]
-    for (const s of below) {
-      if (s) results.push({ ...s, y: targetY })
+  const results: SnapResult[] = []
+  for (const targetY of floors) {
+    for (const s of [
+      findSquareEdgeSnap(wx, wz, targetY, coordinateIndex),
+      findSnappedSquareEdgeSnap(wx, wz, targetY, pieces, coordinateIndex),
+      findTriEdgeSnap(wx, wz, targetY, pieces, coordinateIndex),
+    ]) { if (s) results.push(s) }
+    if (targetY > 0) {
+      for (const s of [
+        findSquareEdgeSnap(wx, wz, targetY - 1, coordinateIndex),
+        findSnappedSquareEdgeSnap(wx, wz, targetY - 1, pieces, coordinateIndex),
+        findTriEdgeSnap(wx, wz, targetY - 1, pieces, coordinateIndex),
+      ]) { if (s) results.push({ ...s, y: targetY }) }
     }
   }
-  return results.filter((s): s is SnapResult => s !== null)
+  return results
 }
 
 function collectSquareFloorSnaps(
-  wx: number, wz: number, targetY: number,
+  wx: number, wz: number, floors: number[],
   pieces: PlacedPiece[], coordinateIndex: Map<string, string>,
 ): SquareSnapResult[] {
-  const results: (SquareSnapResult | null)[] = [
-    findTriEdgeForSquareSnap(wx, wz, targetY, pieces, coordinateIndex),
-    findSquareSnapNeighbor(wx, wz, targetY, pieces, coordinateIndex),
-  ]
-  if (targetY > 0) {
-    const below = [
-      findTriEdgeForSquareSnap(wx, wz, targetY - 1, pieces, coordinateIndex),
-      findSquareSnapNeighbor(wx, wz, targetY - 1, pieces, coordinateIndex),
-    ]
-    for (const s of below) {
-      if (s) results.push({ ...s, y: targetY })
+  const results: SquareSnapResult[] = []
+  for (const targetY of floors) {
+    for (const s of [
+      findTriEdgeForSquareSnap(wx, wz, targetY, pieces, coordinateIndex),
+      findSquareSnapNeighbor(wx, wz, targetY, pieces, coordinateIndex),
+    ]) { if (s) results.push(s) }
+    if (targetY > 0) {
+      for (const s of [
+        findTriEdgeForSquareSnap(wx, wz, targetY - 1, pieces, coordinateIndex),
+        findSquareSnapNeighbor(wx, wz, targetY - 1, pieces, coordinateIndex),
+      ]) { if (s) results.push({ ...s, y: targetY }) }
     }
   }
-  return results.filter((s): s is SquareSnapResult => s !== null)
+  return results
 }
 
 export function TriHitPlane({ floorY }: HitPlaneProps) {
@@ -547,10 +547,15 @@ export function TriHitPlane({ floorY }: HitPlaneProps) {
   // Triangle edge piece types don't exist — skip
   if (isTriType && isEdgeType) return null
 
+  // All visible upper floors to scan for snap targets
+  const upperFloors = ([1, 2] as const).filter((f) => visibleLevels.has(f)) as number[]
+  // For ground-only pieces, just use floorY; for upper/null, scan upper floors
+  const snapFloors = pieceConfig.floorConstraint === 'ground_only' ? [floorY] : (upperFloors.length > 0 ? upperFloors : [floorY])
+
   function handlePointerMove(e: ThreeEvent<PointerEvent>) {
     // Square cell snapping to triangle edges or adjacent snapped squares
     if (isSquareSnapType) {
-      const sqCandidates = collectSquareFloorSnaps(e.point.x, e.point.z, floorY, pieces, coordinateIndex)
+      const sqCandidates = collectSquareFloorSnaps(e.point.x, e.point.z, snapFloors, pieces, coordinateIndex)
       const sqSnap = pickClosestSquareSnap(sqCandidates, e.point.x, e.point.z)
       if (sqSnap) {
         e.stopPropagation()
@@ -603,7 +608,7 @@ export function TriHitPlane({ floorY }: HitPlaneProps) {
 
     // Triangle cell piece: always claim the event
     e.stopPropagation()
-    const snapCandidates = collectFloorSnaps(e.point.x, e.point.z, floorY, pieces, coordinateIndex)
+    const snapCandidates = collectFloorSnaps(e.point.x, e.point.z, snapFloors, pieces, coordinateIndex)
     const snap = pickClosestSnap(snapCandidates, e.point.x, e.point.z)
     if (snap) {
       const triCoord: TriCoord = { hq: 0, hr: 0, slot: 0 }
@@ -625,7 +630,7 @@ export function TriHitPlane({ floorY }: HitPlaneProps) {
     if (e.delta > 5) return
     // Square cell snapping to triangle edges or adjacent snapped squares
     if (isSquareSnapType) {
-      const sqCandidates = collectSquareFloorSnaps(e.point.x, e.point.z, floorY, pieces, coordinateIndex)
+      const sqCandidates = collectSquareFloorSnaps(e.point.x, e.point.z, snapFloors, pieces, coordinateIndex)
       const sqSnap = pickClosestSquareSnap(sqCandidates, e.point.x, e.point.z)
       if (sqSnap) {
         e.stopPropagation()
@@ -681,7 +686,7 @@ export function TriHitPlane({ floorY }: HitPlaneProps) {
     e.stopPropagation()
 
     // Check for snap — pick whichever candidate centroid is closest to cursor
-    const snapCandidates = collectFloorSnaps(e.point.x, e.point.z, floorY, pieces, coordinateIndex)
+    const snapCandidates = collectFloorSnaps(e.point.x, e.point.z, snapFloors, pieces, coordinateIndex)
     const snap = pickClosestSnap(snapCandidates, e.point.x, e.point.z)
     if (snap) {
       if (canPlaceTriSnap(selectedPieceType!, snap, pieces, coordinateIndex, config)) {

--- a/src/scene/HitPlane.tsx
+++ b/src/scene/HitPlane.tsx
@@ -7,7 +7,7 @@ import piecesConfig from '../data/pieces-config.json'
 import type { PiecesConfig, XYZ, PieceSide, PieceRotation, PlacedPiece } from '../types'
 import GhostPiece from './GhostPiece'
 import { worldToTriCoord, triSlotWorldPosition, triSlotRotationDeg, triEdgeWorldPosition, triEdgeRotationDeg, detectTriEdge, squareEdgeSnapPosition, triSnapNeighbors, triSnapEdgeWorldPosition, triSnapEdgeRotationDeg, detectTriSnapEdge, triEdgeSquareSnapPosition, triSnapEdgeSquareSnapPosition, squareSnapEdgeWorldPosition, squareSnapEdgeRotationDeg, detectSquareSnapSide, HEX_ORIGIN } from '../utils/hexGrid'
-import { toKey, toTriKey, toTriSnapKey, toSquareSnapKey } from '../utils/coordinateKey'
+import { toKey, toEdgeKey, toTriKey, toTriEdgeKey, toTriSnapKey, toSquareSnapKey } from '../utils/coordinateKey'
 import { PIECE_COLORS, DEFAULT_COLOR } from './pieceGeometry'
 import CellMesh from './CellMesh'
 import EdgeMesh from './EdgeMesh'
@@ -31,6 +31,7 @@ export default function HitPlane({ floorY }: HitPlaneProps) {
   const selectedPieceType = useStore((s) => s.selectedPieceType)
   const pieces = useStore((s) => s.pieces)
   const coordinateIndex = useStore((s) => s.coordinateIndex)
+  const visibleLevels = useStore((s) => s.visibleLevels)
   const placePiece = useStore((s) => s.placePiece)
   const [ghost, setGhost] = useState<GhostState | null>(null)
 
@@ -46,16 +47,36 @@ export default function HitPlane({ floorY }: HitPlaneProps) {
   function toGhostState(point: { x: number; z: number }): GhostState {
     const cellX = Math.max(0, Math.min(GRID_W - 1, Math.floor(point.x)))
     const cellZ = Math.max(0, Math.min(GRID_L - 1, Math.floor(point.z)))
-    const pos: XYZ = { x: cellX, y: floorY, z: cellZ }
 
     if (isEdgePiece) {
       const localX = point.x - cellX
       const localZ = point.z - cellZ
       const side = detectSide(localX, localZ)
-      return { pos, side, rotation: 0 }
+      // Scan visible floors top-to-bottom: target highest floor with support
+      // (foundation cell piece, or edge piece below on same side for stacking)
+      for (const f of [1, 0] as const) {
+        if (!visibleLevels.has(f)) continue
+        const hasFoundation = coordinateIndex.has(toKey({ x: cellX, y: f, z: cellZ }))
+        const hasEdgeBelow = f > 0
+          && coordinateIndex.has(toEdgeKey({ x: cellX, y: f - 1, z: cellZ }, side))
+        if (hasFoundation || hasEdgeBelow) {
+          return { pos: { x: cellX, y: f, z: cellZ }, side, rotation: 0 }
+        }
+      }
+      return { pos: { x: cellX, y: floorY, z: cellZ }, side, rotation: 0 }
     }
 
-    return { pos, rotation: 0 }
+    // Cell pieces: scan visible floors bottom-to-top for first unoccupied cell
+    const constraint = pieceConfig.floorConstraint
+    for (const f of [0, 1, 2] as const) {
+      if (!visibleLevels.has(f)) continue
+      if (constraint === 'ground_only' && f !== 0) continue
+      if (constraint === 'upper_only' && f === 0) continue
+      if (!coordinateIndex.has(toKey({ x: cellX, y: f, z: cellZ }))) {
+        return { pos: { x: cellX, y: f, z: cellZ }, rotation: 0 }
+      }
+    }
+    return { pos: { x: cellX, y: floorY, z: cellZ }, rotation: 0 }
   }
 
   function handlePointerMove(e: ThreeEvent<PointerEvent>) {
@@ -193,6 +214,64 @@ function findSquareEdgeSnap(
   return { ...sp, y }
 }
 
+/** Find the nearest snapped-square edge to place a triangle against. */
+function findSnappedSquareEdgeSnap(
+  wx: number, wz: number, y: number,
+  pieces: PlacedPiece[],
+  coordinateIndex: Map<string, string>,
+): SnapResult | null {
+  const SQRT3 = Math.sqrt(3)
+  const inR = 1 / (2 * SQRT3)
+  const sides: PieceSide[] = ['north', 'east', 'south', 'west']
+  const baseAngle: Record<PieceSide, number> = { east: 0, west: 180, south: 90, north: 270 }
+  const normals: Record<PieceSide, [number, number]> = {
+    north: [0, -1], east: [1, 0], south: [0, 1], west: [-1, 0],
+  }
+  const edgeMid: Record<PieceSide, [number, number]> = {
+    north: [0, -0.5], east: [0.5, 0], south: [0, 0.5], west: [-0.5, 0],
+  }
+
+  let bestDist = SNAP_THRESHOLD
+  let best: SnapResult | null = null
+
+  for (const piece of pieces) {
+    if (!piece.squareSnap || piece.side || piece.position.y !== y) continue
+    const { worldX, worldZ, rotDeg } = piece.squareSnap
+    const dx = wx - worldX
+    const dz = wz - worldZ
+    if (dx * dx + dz * dz > 4) continue
+
+    const theta = (rotDeg * Math.PI) / 180
+    const cosT = Math.cos(theta)
+    const sinT = Math.sin(theta)
+
+    for (const side of sides) {
+      const [lmx, lmz] = edgeMid[side]
+      const [lnx, lnz] = normals[side]
+
+      // Edge midpoint in world (for distance check)
+      const emx = worldX + lmx * cosT + lmz * sinT
+      const emz = worldZ - lmx * sinT + lmz * cosT
+      const dist = Math.sqrt((wx - emx) ** 2 + (wz - emz) ** 2)
+      if (dist >= bestDist) continue
+
+      // Triangle center in world
+      const lcx = lmx + inR * lnx
+      const lcz = lmz + inR * lnz
+      const tcx = worldX + lcx * cosT + lcz * sinT
+      const tcz = worldZ - lcx * sinT + lcz * cosT
+
+      const snapKey = toTriSnapKey(tcx, y, tcz)
+      if (coordinateIndex.has(snapKey)) continue
+
+      bestDist = dist
+      best = { worldX: tcx, worldZ: tcz, angleDeg: baseAngle[side] + rotDeg, y }
+    }
+  }
+
+  return best
+}
+
 /** Find the nearest free edge of a placed snap-triangle within threshold. */
 function findTriEdgeSnap(
   wx: number, wz: number, y: number,
@@ -301,6 +380,46 @@ function findTriEdgeForSquareSnap(
   return best
 }
 
+/** Find an adjacent position to an existing snapped square (square-to-square chaining). */
+function findSquareSnapNeighbor(
+  wx: number, wz: number, y: number,
+  pieces: PlacedPiece[],
+  coordinateIndex: Map<string, string>,
+): SquareSnapResult | null {
+  let bestDist = SNAP_THRESHOLD
+  let best: SquareSnapResult | null = null
+
+  const offsets = [[0, -1], [1, 0], [0, 1], [-1, 0]]
+
+  for (const piece of pieces) {
+    if (!piece.squareSnap || piece.side || piece.position.y !== y) continue
+    const { worldX, worldZ, rotDeg } = piece.squareSnap
+    const dx = wx - worldX
+    const dz = wz - worldZ
+    if (dx * dx + dz * dz > 4) continue
+
+    const angle = (rotDeg * Math.PI) / 180
+    const cosA = Math.cos(angle)
+    const sinA = Math.sin(angle)
+
+    for (const [ldx, ldz] of offsets) {
+      const nx = worldX + ldx * cosA + ldz * sinA
+      const nz = worldZ - ldx * sinA + ldz * cosA
+
+      const snapKey = toSquareSnapKey(nx, y, nz)
+      if (coordinateIndex.has(snapKey)) continue
+
+      const dist = Math.sqrt((wx - nx) ** 2 + (wz - nz) ** 2)
+      if (dist < bestDist) {
+        bestDist = dist
+        best = { worldX: nx, worldZ: nz, rotDeg, y }
+      }
+    }
+  }
+
+  return best
+}
+
 /** Find the nearest snap-placed square whose edge the cursor is near (for edge piece placement). */
 function findSquareSnapForEdge(
   wx: number, wz: number, y: number,
@@ -327,10 +446,83 @@ function findSquareSnapForEdge(
   return best
 }
 
+/** Given multiple snap candidates, return the one closest to the cursor. */
+function pickClosestSnap(candidates: (SnapResult | null)[], wx: number, wz: number): SnapResult | null {
+  let best: SnapResult | null = null
+  let bestDist = Infinity
+  for (const c of candidates) {
+    if (!c) continue
+    const dist = (wx - c.worldX) ** 2 + (wz - c.worldZ) ** 2
+    if (dist < bestDist) {
+      bestDist = dist
+      best = c
+    }
+  }
+  return best
+}
+
+function pickClosestSquareSnap(candidates: (SquareSnapResult | null)[], wx: number, wz: number): SquareSnapResult | null {
+  let best: SquareSnapResult | null = null
+  let bestDist = Infinity
+  for (const c of candidates) {
+    if (!c) continue
+    const dist = (wx - c.worldX) ** 2 + (wz - c.worldZ) ** 2
+    if (dist < bestDist) {
+      bestDist = dist
+      best = c
+    }
+  }
+  return best
+}
+
+/** Collect snap results from both the target floor and the floor below, overriding y to targetY. */
+function collectFloorSnaps(
+  wx: number, wz: number, targetY: number,
+  pieces: PlacedPiece[], coordinateIndex: Map<string, string>,
+): SnapResult[] {
+  const results: (SnapResult | null)[] = [
+    findSquareEdgeSnap(wx, wz, targetY, coordinateIndex),
+    findSnappedSquareEdgeSnap(wx, wz, targetY, pieces, coordinateIndex),
+    findTriEdgeSnap(wx, wz, targetY, pieces, coordinateIndex),
+  ]
+  if (targetY > 0) {
+    const below = [
+      findSquareEdgeSnap(wx, wz, targetY - 1, coordinateIndex),
+      findSnappedSquareEdgeSnap(wx, wz, targetY - 1, pieces, coordinateIndex),
+      findTriEdgeSnap(wx, wz, targetY - 1, pieces, coordinateIndex),
+    ]
+    for (const s of below) {
+      if (s) results.push({ ...s, y: targetY })
+    }
+  }
+  return results.filter((s): s is SnapResult => s !== null)
+}
+
+function collectSquareFloorSnaps(
+  wx: number, wz: number, targetY: number,
+  pieces: PlacedPiece[], coordinateIndex: Map<string, string>,
+): SquareSnapResult[] {
+  const results: (SquareSnapResult | null)[] = [
+    findTriEdgeForSquareSnap(wx, wz, targetY, pieces, coordinateIndex),
+    findSquareSnapNeighbor(wx, wz, targetY, pieces, coordinateIndex),
+  ]
+  if (targetY > 0) {
+    const below = [
+      findTriEdgeForSquareSnap(wx, wz, targetY - 1, pieces, coordinateIndex),
+      findSquareSnapNeighbor(wx, wz, targetY - 1, pieces, coordinateIndex),
+    ]
+    for (const s of below) {
+      if (s) results.push({ ...s, y: targetY })
+    }
+  }
+  return results.filter((s): s is SquareSnapResult => s !== null)
+}
+
 export function TriHitPlane({ floorY }: HitPlaneProps) {
   const selectedPieceType = useStore((s) => s.selectedPieceType)
   const pieces = useStore((s) => s.pieces)
   const coordinateIndex = useStore((s) => s.coordinateIndex)
+  const visibleLevels = useStore((s) => s.visibleLevels)
   const placeTrianglePiece = useStore((s) => s.placeTrianglePiece)
   const placeTriangleEdgePiece = useStore((s) => s.placeTriangleEdgePiece)
   const placeTriangleSnapped = useStore((s) => s.placeTriangleSnapped)
@@ -356,9 +548,10 @@ export function TriHitPlane({ floorY }: HitPlaneProps) {
   if (isTriType && isEdgeType) return null
 
   function handlePointerMove(e: ThreeEvent<PointerEvent>) {
-    // Square cell snapping to triangle edges
+    // Square cell snapping to triangle edges or adjacent snapped squares
     if (isSquareSnapType) {
-      const sqSnap = findTriEdgeForSquareSnap(e.point.x, e.point.z, floorY, pieces, coordinateIndex)
+      const sqCandidates = collectSquareFloorSnaps(e.point.x, e.point.z, floorY, pieces, coordinateIndex)
+      const sqSnap = pickClosestSquareSnap(sqCandidates, e.point.x, e.point.z)
       if (sqSnap) {
         e.stopPropagation()
         const triCoord: TriCoord = { hq: 0, hr: 0, slot: 0 }
@@ -370,31 +563,38 @@ export function TriHitPlane({ floorY }: HitPlaneProps) {
     }
 
     if (isEdgeType) {
-      // Check hex-grid triangles
+      // Scan visible floors top-to-bottom for a foundation or edge-below to attach to
       const { hq, hr, slot } = worldToTriCoord(e.point.x, e.point.z)
-      const triCoord: TriCoord = { hq, hr, slot: slot as TriCoord['slot'] }
-      const triKey = toTriKey(hq, floorY, hr, slot)
-      if (coordinateIndex.has(triKey)) {
-        e.stopPropagation()
-        const edge = detectTriEdge(hq, hr, slot, e.point.x, e.point.z)
-        setGhost({ triCoord, y: floorY, triEdge: edge })
-        return
-      }
-      // Check snap-placed triangles
-      const se = findSnapTriForEdge(e.point.x, e.point.z, floorY, pieces)
-      if (se) {
-        e.stopPropagation()
-        const triCoord2: TriCoord = { hq: 0, hr: 0, slot: 0 }
-        setGhost({ triCoord: triCoord2, y: floorY, snapEdge: se })
-        return
-      }
-      // Check snap-placed squares
-      const sqse = findSquareSnapForEdge(e.point.x, e.point.z, floorY, pieces)
-      if (sqse) {
-        e.stopPropagation()
-        const triCoord3: TriCoord = { hq: 0, hr: 0, slot: 0 }
-        setGhost({ triCoord: triCoord3, y: floorY, squareSnapEdge: sqse })
-        return
+      const detectedEdge = detectTriEdge(hq, hr, slot, e.point.x, e.point.z)
+      for (const f of [1, 0] as const) {
+        if (!visibleLevels.has(f)) continue
+        // Check hex-grid triangles (foundation or edge stacking)
+        const triKey = toTriKey(hq, f, hr, slot)
+        const hasTriFound = coordinateIndex.has(triKey)
+        const hasTriEdgeBelow = f > 0
+          && coordinateIndex.has(toTriEdgeKey(hq, f - 1, hr, slot, detectedEdge))
+        if (hasTriFound || hasTriEdgeBelow) {
+          e.stopPropagation()
+          const triCoord: TriCoord = { hq, hr, slot: slot as TriCoord['slot'] }
+          setGhost({ triCoord, y: f, triEdge: detectedEdge })
+          return
+        }
+        // Check snap-placed triangles
+        const se = findSnapTriForEdge(e.point.x, e.point.z, f, pieces)
+        if (se) {
+          e.stopPropagation()
+          const triCoord2: TriCoord = { hq: 0, hr: 0, slot: 0 }
+          setGhost({ triCoord: triCoord2, y: f, snapEdge: se })
+          return
+        }
+        // Check snap-placed squares
+        const sqse = findSquareSnapForEdge(e.point.x, e.point.z, f, pieces)
+        if (sqse) {
+          e.stopPropagation()
+          const triCoord3: TriCoord = { hq: 0, hr: 0, slot: 0 }
+          setGhost({ triCoord: triCoord3, y: f, squareSnapEdge: sqse })
+          return
+        }
       }
       // No triangle/square found — let event pass through to square HitPlane
       setGhost(null)
@@ -403,8 +603,8 @@ export function TriHitPlane({ floorY }: HitPlaneProps) {
 
     // Triangle cell piece: always claim the event
     e.stopPropagation()
-    const snap = findSquareEdgeSnap(e.point.x, e.point.z, floorY, coordinateIndex)
-      ?? findTriEdgeSnap(e.point.x, e.point.z, floorY, pieces, coordinateIndex)
+    const snapCandidates = collectFloorSnaps(e.point.x, e.point.z, floorY, pieces, coordinateIndex)
+    const snap = pickClosestSnap(snapCandidates, e.point.x, e.point.z)
     if (snap) {
       const triCoord: TriCoord = { hq: 0, hr: 0, slot: 0 }
       setGhost({ triCoord, y: floorY, snap })
@@ -423,9 +623,10 @@ export function TriHitPlane({ floorY }: HitPlaneProps) {
 
   function handleClick(e: ThreeEvent<MouseEvent>) {
     if (e.delta > 5) return
-    // Square cell snapping to triangle edges
+    // Square cell snapping to triangle edges or adjacent snapped squares
     if (isSquareSnapType) {
-      const sqSnap = findTriEdgeForSquareSnap(e.point.x, e.point.z, floorY, pieces, coordinateIndex)
+      const sqCandidates = collectSquareFloorSnaps(e.point.x, e.point.z, floorY, pieces, coordinateIndex)
+      const sqSnap = pickClosestSquareSnap(sqCandidates, e.point.x, e.point.z)
       if (sqSnap) {
         e.stopPropagation()
         if (canPlaceSquareSnap(selectedPieceType!, sqSnap, pieces, coordinateIndex, config)) {
@@ -436,33 +637,41 @@ export function TriHitPlane({ floorY }: HitPlaneProps) {
     }
 
     if (isEdgeType) {
-      // Check hex-grid triangles
+      // Scan visible floors top-to-bottom for a foundation or edge-below to attach to
       const { hq, hr, slot } = worldToTriCoord(e.point.x, e.point.z)
-      const triKey = toTriKey(hq, floorY, hr, slot)
-      if (coordinateIndex.has(triKey)) {
-        e.stopPropagation()
-        const triCoord: TriCoord = { hq, hr, slot: slot as TriCoord['slot'] }
-        const edge = detectTriEdge(hq, hr, slot, e.point.x, e.point.z)
-        if (canPlace(selectedPieceType!, { x: 0, y: floorY, z: 0 }, pieces, coordinateIndex, config, undefined, triCoord, edge)) {
-          placeTriangleEdgePiece(selectedPieceType!, floorY, triCoord, edge)
+      const detectedEdge = detectTriEdge(hq, hr, slot, e.point.x, e.point.z)
+      for (const f of [1, 0] as const) {
+        if (!visibleLevels.has(f)) continue
+        // Check hex-grid triangles (foundation or edge stacking)
+        const triKey = toTriKey(hq, f, hr, slot)
+        const hasTriFound = coordinateIndex.has(triKey)
+        const hasTriEdgeBelow = f > 0
+          && coordinateIndex.has(toTriEdgeKey(hq, f - 1, hr, slot, detectedEdge))
+        if (hasTriFound || hasTriEdgeBelow) {
+          e.stopPropagation()
+          const triCoord: TriCoord = { hq, hr, slot: slot as TriCoord['slot'] }
+          if (canPlace(selectedPieceType!, { x: 0, y: f, z: 0 }, pieces, coordinateIndex, config, undefined, triCoord, detectedEdge)) {
+            placeTriangleEdgePiece(selectedPieceType!, f, triCoord, detectedEdge)
+          }
+          return
         }
-        return
-      }
-      // Check snap-placed triangles
-      const se = findSnapTriForEdge(e.point.x, e.point.z, floorY, pieces)
-      if (se) {
-        e.stopPropagation()
-        if (canPlaceTriSnapEdge(selectedPieceType!, se.parentSnap, floorY, se.edge, pieces, coordinateIndex, config)) {
-          placeTriSnapEdgePiece(selectedPieceType!, se.parentSnap, floorY, se.edge)
+        // Check snap-placed triangles
+        const se = findSnapTriForEdge(e.point.x, e.point.z, f, pieces)
+        if (se) {
+          e.stopPropagation()
+          if (canPlaceTriSnapEdge(selectedPieceType!, se.parentSnap, f, se.edge, pieces, coordinateIndex, config)) {
+            placeTriSnapEdgePiece(selectedPieceType!, se.parentSnap, f, se.edge)
+          }
+          return
         }
-        return
-      }
-      // Check snap-placed squares
-      const sqse = findSquareSnapForEdge(e.point.x, e.point.z, floorY, pieces)
-      if (sqse) {
-        e.stopPropagation()
-        if (canPlaceSquareSnapEdge(selectedPieceType!, sqse.parentSnap, floorY, sqse.side, pieces, coordinateIndex, config)) {
-          placeSquareSnapEdgePiece(selectedPieceType!, sqse.parentSnap, floorY, sqse.side)
+        // Check snap-placed squares
+        const sqse = findSquareSnapForEdge(e.point.x, e.point.z, f, pieces)
+        if (sqse) {
+          e.stopPropagation()
+          if (canPlaceSquareSnapEdge(selectedPieceType!, sqse.parentSnap, f, sqse.side, pieces, coordinateIndex, config)) {
+            placeSquareSnapEdgePiece(selectedPieceType!, sqse.parentSnap, f, sqse.side)
+          }
+          return
         }
       }
       return
@@ -471,9 +680,9 @@ export function TriHitPlane({ floorY }: HitPlaneProps) {
     // Triangle cell piece: always claim the event
     e.stopPropagation()
 
-    // Check for snap (square edge, then triangle free edge)
-    const snap = findSquareEdgeSnap(e.point.x, e.point.z, floorY, coordinateIndex)
-      ?? findTriEdgeSnap(e.point.x, e.point.z, floorY, pieces, coordinateIndex)
+    // Check for snap — pick whichever candidate centroid is closest to cursor
+    const snapCandidates = collectFloorSnaps(e.point.x, e.point.z, floorY, pieces, coordinateIndex)
+    const snap = pickClosestSnap(snapCandidates, e.point.x, e.point.z)
     if (snap) {
       if (canPlaceTriSnap(selectedPieceType!, snap, pieces, coordinateIndex, config)) {
         placeTriangleSnapped(selectedPieceType!, snap)

--- a/src/scene/PlacedPieces.tsx
+++ b/src/scene/PlacedPieces.tsx
@@ -1,8 +1,14 @@
+import { useState } from 'react'
 import { useStore } from '../store/useStore'
 import { PIECE_COLORS, DEFAULT_COLOR, getPiecePosition, isTriangleType, getCellPieceShape } from './pieceGeometry'
 import EdgeMesh from './EdgeMesh'
 import CellMesh from './CellMesh'
 import { triSlotWorldPosition, triSlotRotationDeg, triEdgeWorldPosition, triEdgeRotationDeg, triSnapEdgeWorldPosition, triSnapEdgeRotationDeg, squareSnapEdgeWorldPosition, squareSnapEdgeRotationDeg } from '../utils/hexGrid'
+import { canPlace, canPlaceTriSnap, canPlaceTriSnapEdge, canPlaceSquareSnap, canPlaceSquareSnapEdge } from '../utils/validation'
+import piecesConfig from '../data/pieces-config.json'
+import type { PiecesConfig, PlacedPiece } from '../types'
+
+const edgeConfig = piecesConfig as PiecesConfig
 
 export default function PlacedPieces() {
   const pieces = useStore((s) => s.pieces)
@@ -10,6 +16,96 @@ export default function PlacedPieces() {
   const selectedPieceType = useStore((s) => s.selectedPieceType)
   const selectedPieceId = useStore((s) => s.selectedPieceId)
   const selectPiece = useStore((s) => s.selectPiece)
+  const coordinateIndex = useStore((s) => s.coordinateIndex)
+  const placePiece = useStore((s) => s.placePiece)
+  const placeTriangleEdgePiece = useStore((s) => s.placeTriangleEdgePiece)
+  const placeTriSnapEdgePiece = useStore((s) => s.placeTriSnapEdgePiece)
+  const placeSquareSnapEdgePiece = useStore((s) => s.placeSquareSnapEdgePiece)
+  const placeTrianglePiece = useStore((s) => s.placeTrianglePiece)
+  const placeTriangleSnapped = useStore((s) => s.placeTriangleSnapped)
+  const placeSquareSnapped = useStore((s) => s.placeSquareSnapped)
+  const [stackTargetId, setStackTargetId] = useState<string | null>(null)
+
+  const isEdgePlacement = selectedPieceType != null
+    && edgeConfig[selectedPieceType]?.placementType === 'edge'
+  const isFloorPlacement = selectedPieceType != null
+    && edgeConfig[selectedPieceType]?.placementType === 'cell'
+    && edgeConfig[selectedPieceType]?.floorConstraint === 'upper_only'
+  const isTriFloor = isFloorPlacement && selectedPieceType!.includes('triangle')
+  const isSquareFloor = isFloorPlacement && !selectedPieceType!.includes('triangle')
+
+  function canStackOn(piece: PlacedPiece): boolean {
+    if (!selectedPieceType || !isEdgePlacement) return false
+    const sy = piece.position.y + 1
+    if (piece.squareSnap && piece.side) {
+      return canPlaceSquareSnapEdge(selectedPieceType, piece.squareSnap, sy, piece.side, pieces, coordinateIndex, edgeConfig)
+    }
+    if (piece.triSnap && piece.triEdge !== undefined) {
+      return canPlaceTriSnapEdge(selectedPieceType, piece.triSnap, sy, piece.triEdge, pieces, coordinateIndex, edgeConfig)
+    }
+    if (piece.triCoord && piece.triEdge !== undefined) {
+      return canPlace(selectedPieceType, { x: 0, y: sy, z: 0 }, pieces, coordinateIndex, edgeConfig, undefined, piece.triCoord, piece.triEdge as 0 | 1 | 2)
+    }
+    if (piece.side) {
+      return canPlace(selectedPieceType, { ...piece.position, y: sy }, pieces, coordinateIndex, edgeConfig, piece.side)
+    }
+    return false
+  }
+
+  function placeOnTop(piece: PlacedPiece) {
+    if (!selectedPieceType) return
+    const sy = piece.position.y + 1
+    if (piece.squareSnap && piece.side) {
+      placeSquareSnapEdgePiece(selectedPieceType, piece.squareSnap, sy, piece.side)
+    } else if (piece.triSnap && piece.triEdge !== undefined) {
+      placeTriSnapEdgePiece(selectedPieceType, piece.triSnap, sy, piece.triEdge as 0 | 1 | 2)
+    } else if (piece.triCoord && piece.triEdge !== undefined) {
+      placeTriangleEdgePiece(selectedPieceType, sy, piece.triCoord, piece.triEdge as 0 | 1 | 2)
+    } else if (piece.side) {
+      placePiece(selectedPieceType, { ...piece.position, y: sy }, 0, piece.side)
+    }
+  }
+
+  /** Can a floor piece be placed on the level above this edge piece? */
+  function canFloorAbove(piece: PlacedPiece): boolean {
+    if (!selectedPieceType || !isFloorPlacement) return false
+    const sy = piece.position.y + 1
+    // Grid square edge → square floor above
+    if (piece.side && !piece.squareSnap && !piece.triSnap && !piece.triCoord) {
+      if (!isSquareFloor) return false
+      return canPlace(selectedPieceType, { ...piece.position, y: sy }, pieces, coordinateIndex, edgeConfig)
+    }
+    // Snap-placed square edge → square floor above
+    if (piece.squareSnap && piece.side) {
+      if (!isSquareFloor) return false
+      return canPlaceSquareSnap(selectedPieceType, { ...piece.squareSnap, y: sy }, pieces, coordinateIndex, edgeConfig)
+    }
+    // Snap-placed triangle edge → triangle floor above
+    if (piece.triSnap && piece.triEdge !== undefined) {
+      if (!isTriFloor) return false
+      return canPlaceTriSnap(selectedPieceType, { ...piece.triSnap, y: sy }, pieces, coordinateIndex, edgeConfig)
+    }
+    // Hex-grid triangle edge → triangle floor above
+    if (piece.triCoord && piece.triEdge !== undefined) {
+      if (!isTriFloor) return false
+      return canPlace(selectedPieceType, { x: 0, y: sy, z: 0 }, pieces, coordinateIndex, edgeConfig, undefined, piece.triCoord)
+    }
+    return false
+  }
+
+  function placeFloorAbove(piece: PlacedPiece) {
+    if (!selectedPieceType) return
+    const sy = piece.position.y + 1
+    if (piece.side && !piece.squareSnap && !piece.triSnap && !piece.triCoord) {
+      placePiece(selectedPieceType, { ...piece.position, y: sy }, 0)
+    } else if (piece.squareSnap && piece.side) {
+      placeSquareSnapped(selectedPieceType, { ...piece.squareSnap, y: sy })
+    } else if (piece.triSnap && piece.triEdge !== undefined) {
+      placeTriangleSnapped(selectedPieceType, { ...piece.triSnap, y: sy })
+    } else if (piece.triCoord && piece.triEdge !== undefined) {
+      placeTrianglePiece(selectedPieceType, sy, piece.triCoord)
+    }
+  }
 
   return (
     <>
@@ -23,10 +119,8 @@ export default function PlacedPieces() {
         const renderRotation = piece.rotation
         const isSelectMode = selectedPieceType === null
 
-        const canSelect = isSelectMode || piece.type === selectedPieceType
-
         const handleClick = (e: { stopPropagation: () => void }) => {
-          if (canSelect) {
+          if (isSelectMode) {
             e.stopPropagation()
             selectPiece(isSelected ? null : piece.id)
           }
@@ -39,19 +133,55 @@ export default function PlacedPieces() {
           const edgeRotDeg = squareSnapEdgeRotationDeg(rotDeg, piece.side)
           const rotRad = (edgeRotDeg * Math.PI) / 180
           const wallH = piece.type.includes('low') || piece.type.includes('barrier') ? 0.33 : 0.95
+          const canStack = isEdgePlacement && piece.position.y < 1
+          const canFloor = isSquareFloor && piece.position.y < 2
+          const canInteract = canStack || canFloor
+          const isTarget = stackTargetId === piece.id
+          const interactHandlers = canInteract ? {
+            onPointerMove: (ev: { stopPropagation: () => void }) => ev.stopPropagation(),
+            onPointerOver: () => setStackTargetId(piece.id),
+            onPointerOut: () => setStackTargetId((p) => p === piece.id ? null : p),
+            onClick: (ev: { stopPropagation: () => void; delta?: number }) => {
+              if ((ev as any).delta > 5) return
+              ev.stopPropagation()
+              if (canStack && canStackOn(piece)) placeOnTop(piece)
+              else if (canFloor && canFloorAbove(piece)) placeFloorAbove(piece)
+            },
+          } : {}
+          // Edge stacking ghost
+          const edgeGhostWp = canStack && isTarget
+            ? squareSnapEdgeWorldPosition(worldX, worldZ, rotDeg, piece.position.y + 1, piece.side)
+            : null
+          const gWallH = selectedPieceType?.includes('low') || selectedPieceType?.includes('barrier') ? 0.33 : 0.95
+          // Floor ghost
+          const floorGhost = canFloor && isTarget && !canStack
+          const ghostColor = isTarget && (canStack ? canStackOn(piece) : canFloorAbove(piece))
+            ? (PIECE_COLORS[selectedPieceType!] ?? DEFAULT_COLOR) : '#ff3333'
+          const cellShape = floorGhost && selectedPieceType ? getCellPieceShape(selectedPieceType) : null
           return (
-            <group
-              key={piece.id}
-              position={[wp.x, wp.y + wallH / 2, wp.z]}
-              rotation={[0, rotRad, 0]}
-              onClick={handleClick}
-            >
-              <EdgeMesh
-                type={piece.type}
-                side="north"
-                color={color}
-                opacity={isSelectMode ? 0.8 : 1}
-              />
+            <group key={piece.id}>
+              <group
+                position={[wp.x, wp.y + wallH / 2, wp.z]}
+                rotation={[0, rotRad, 0]}
+                {...canInteract ? interactHandlers : { onClick: handleClick }}
+              >
+                <EdgeMesh
+                  type={piece.type}
+                  side="north"
+                  color={color}
+                  opacity={isSelectMode ? 0.8 : 1}
+                />
+              </group>
+              {edgeGhostWp && (
+                <group position={[edgeGhostWp.x, edgeGhostWp.y + gWallH / 2, edgeGhostWp.z]} rotation={[0, rotRad, 0]}>
+                  <EdgeMesh type={selectedPieceType!} side="north" color={ghostColor} opacity={0.45} />
+                </group>
+              )}
+              {floorGhost && cellShape && (
+                <group position={[worldX, piece.position.y + 1 + cellShape.offset[1], worldZ]} rotation={[0, (rotDeg * Math.PI) / 180, 0]}>
+                  <CellMesh type={selectedPieceType!} color={ghostColor} opacity={0.45} />
+                </group>
+              )}
             </group>
           )
         }
@@ -84,19 +214,52 @@ export default function PlacedPieces() {
           const rotDeg = triSnapEdgeRotationDeg(worldX, worldZ, angleDeg, piece.triEdge)
           const rotRad = (rotDeg * Math.PI) / 180
           const wallH = piece.type.includes('low') || piece.type.includes('barrier') ? 0.33 : 0.95
+          const canStack = isEdgePlacement && piece.position.y < 1
+          const canFloor = isTriFloor && piece.position.y < 2
+          const canInteract = canStack || canFloor
+          const isTarget = stackTargetId === piece.id
+          const interactHandlers = canInteract ? {
+            onPointerMove: (ev: { stopPropagation: () => void }) => ev.stopPropagation(),
+            onPointerOver: () => setStackTargetId(piece.id),
+            onPointerOut: () => setStackTargetId((p) => p === piece.id ? null : p),
+            onClick: (ev: { stopPropagation: () => void; delta?: number }) => {
+              if ((ev as any).delta > 5) return
+              ev.stopPropagation()
+              if (canStack && canStackOn(piece)) placeOnTop(piece)
+              else if (canFloor && canFloorAbove(piece)) placeFloorAbove(piece)
+            },
+          } : {}
+          const edgeGhostWp = canStack && isTarget
+            ? triSnapEdgeWorldPosition(worldX, worldZ, angleDeg, piece.position.y + 1, piece.triEdge)
+            : null
+          const gWallH = selectedPieceType?.includes('low') || selectedPieceType?.includes('barrier') ? 0.33 : 0.95
+          const floorGhost = canFloor && isTarget && !canStack
+          const ghostColor = isTarget && (canStack ? canStackOn(piece) : canFloorAbove(piece))
+            ? (PIECE_COLORS[selectedPieceType!] ?? DEFAULT_COLOR) : '#ff3333'
           return (
-            <group
-              key={piece.id}
-              position={[wp.x, wp.y + wallH / 2, wp.z]}
-              rotation={[0, rotRad, 0]}
-              onClick={handleClick}
-            >
-              <EdgeMesh
-                type={piece.type}
-                side="north"
-                color={color}
-                opacity={isSelectMode ? 0.8 : 1}
-              />
+            <group key={piece.id}>
+              <group
+                position={[wp.x, wp.y + wallH / 2, wp.z]}
+                rotation={[0, rotRad, 0]}
+                {...canInteract ? interactHandlers : { onClick: handleClick }}
+              >
+                <EdgeMesh
+                  type={piece.type}
+                  side="north"
+                  color={color}
+                  opacity={isSelectMode ? 0.8 : 1}
+                />
+              </group>
+              {edgeGhostWp && (
+                <group position={[edgeGhostWp.x, edgeGhostWp.y + gWallH / 2, edgeGhostWp.z]} rotation={[0, rotRad, 0]}>
+                  <EdgeMesh type={selectedPieceType!} side="north" color={ghostColor} opacity={0.45} />
+                </group>
+              )}
+              {floorGhost && (
+                <group position={[worldX, piece.position.y + 1, worldZ]}>
+                  <CellMesh type={selectedPieceType!} color={ghostColor} opacity={0.45} angleDeg={angleDeg} />
+                </group>
+              )}
             </group>
           )
         }
@@ -122,19 +285,54 @@ export default function PlacedPieces() {
           const rotDeg = triEdgeRotationDeg(slot, piece.triEdge)
           const rotRad = (rotDeg * Math.PI) / 180
           const wallH = piece.type.includes('low') || piece.type.includes('barrier') ? 0.33 : 0.95
+          const canStack = isEdgePlacement && piece.position.y < 1
+          const canFloor = isTriFloor && piece.position.y < 2
+          const canInteract = canStack || canFloor
+          const isTarget = stackTargetId === piece.id
+          const interactHandlers = canInteract ? {
+            onPointerMove: (ev: { stopPropagation: () => void }) => ev.stopPropagation(),
+            onPointerOver: () => setStackTargetId(piece.id),
+            onPointerOut: () => setStackTargetId((p) => p === piece.id ? null : p),
+            onClick: (ev: { stopPropagation: () => void; delta?: number }) => {
+              if ((ev as any).delta > 5) return
+              ev.stopPropagation()
+              if (canStack && canStackOn(piece)) placeOnTop(piece)
+              else if (canFloor && canFloorAbove(piece)) placeFloorAbove(piece)
+            },
+          } : {}
+          const edgeGhostWp = canStack && isTarget
+            ? triEdgeWorldPosition(hq, piece.position.y + 1, hr, slot, piece.triEdge)
+            : null
+          const gWallH = selectedPieceType?.includes('low') || selectedPieceType?.includes('barrier') ? 0.33 : 0.95
+          const floorGhost = canFloor && isTarget && !canStack
+          const ghostColor = isTarget && (canStack ? canStackOn(piece) : canFloorAbove(piece))
+            ? (PIECE_COLORS[selectedPieceType!] ?? DEFAULT_COLOR) : '#ff3333'
+          const floorWp = floorGhost ? triSlotWorldPosition(hq, piece.position.y + 1, hr, slot) : null
+          const floorAngle = floorGhost ? triSlotRotationDeg(slot) : 0
           return (
-            <group
-              key={piece.id}
-              position={[wp.x, wp.y + wallH / 2, wp.z]}
-              rotation={[0, rotRad, 0]}
-              onClick={handleClick}
-            >
-              <EdgeMesh
-                type={piece.type}
-                side="north"
-                color={color}
-                opacity={isSelectMode ? 0.8 : 1}
-              />
+            <group key={piece.id}>
+              <group
+                position={[wp.x, wp.y + wallH / 2, wp.z]}
+                rotation={[0, rotRad, 0]}
+                {...canInteract ? interactHandlers : { onClick: handleClick }}
+              >
+                <EdgeMesh
+                  type={piece.type}
+                  side="north"
+                  color={color}
+                  opacity={isSelectMode ? 0.8 : 1}
+                />
+              </group>
+              {edgeGhostWp && (
+                <group position={[edgeGhostWp.x, edgeGhostWp.y + gWallH / 2, edgeGhostWp.z]} rotation={[0, rotRad, 0]}>
+                  <EdgeMesh type={selectedPieceType!} side="north" color={ghostColor} opacity={0.45} />
+                </group>
+              )}
+              {floorWp && (
+                <group position={[floorWp.x, floorWp.y, floorWp.z]}>
+                  <CellMesh type={selectedPieceType!} color={ghostColor} opacity={0.45} angleDeg={floorAngle} />
+                </group>
+              )}
             </group>
           )
         }
@@ -158,14 +356,53 @@ export default function PlacedPieces() {
 
         // Edge pieces use EdgeMesh for distinct window/doorway shapes
         if (piece.side) {
+          const canStack = isEdgePlacement && piece.position.y < 1
+          const canFloor = isSquareFloor && piece.position.y < 2
+          const canInteract = canStack || canFloor
+          const isTarget = stackTargetId === piece.id
+          const interactHandlers = canInteract ? {
+            onPointerMove: (ev: { stopPropagation: () => void }) => ev.stopPropagation(),
+            onPointerOver: () => setStackTargetId(piece.id),
+            onPointerOut: () => setStackTargetId((p) => p === piece.id ? null : p),
+            onClick: (ev: { stopPropagation: () => void; delta?: number }) => {
+              if ((ev as any).delta > 5) return
+              ev.stopPropagation()
+              if (canStack && canStackOn(piece)) placeOnTop(piece)
+              else if (canFloor && canFloorAbove(piece)) placeFloorAbove(piece)
+            },
+          } : {}
+          const edgeGhostPos = canStack && isTarget
+            ? getPiecePosition({ ...piece.position, y: piece.position.y + 1 }, selectedPieceType!, piece.side)
+            : null
+          const floorGhost = canFloor && isTarget && !canStack
+          const ghostColor = isTarget && (canStack ? canStackOn(piece) : canFloorAbove(piece))
+            ? (PIECE_COLORS[selectedPieceType!] ?? DEFAULT_COLOR) : '#ff3333'
+          const floorGhostPos = floorGhost && selectedPieceType
+            ? getPiecePosition({ ...piece.position, y: piece.position.y + 1 }, selectedPieceType)
+            : null
           return (
-            <group key={piece.id} position={position} onClick={handleClick}>
-              <EdgeMesh
-                type={piece.type}
-                side={piece.side}
-                color={color}
-                opacity={isSelectMode ? 0.8 : 1}
-              />
+            <group key={piece.id}>
+              <group
+                position={position}
+                {...canInteract ? interactHandlers : { onClick: handleClick }}
+              >
+                <EdgeMesh
+                  type={piece.type}
+                  side={piece.side}
+                  color={color}
+                  opacity={isSelectMode ? 0.8 : 1}
+                />
+              </group>
+              {edgeGhostPos && (
+                <group position={edgeGhostPos}>
+                  <EdgeMesh type={selectedPieceType!} side={piece.side} color={ghostColor} opacity={0.45} />
+                </group>
+              )}
+              {floorGhostPos && (
+                <group position={floorGhostPos}>
+                  <CellMesh type={selectedPieceType!} color={ghostColor} opacity={0.45} />
+                </group>
+              )}
             </group>
           )
         }

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -39,18 +39,36 @@ export function hasFoundation(pos: XYZ, coordinateIndex: Map<string, string>): b
   return coordinateIndex.has(toKey(pos))
 }
 
-/** Upper-floor cell pieces need at least one wall/edge piece at the same cell on the floor below. */
+/** Upper-floor cell pieces need wall support below OR an adjacent cell at the same level. */
 export function hasWallSupport(pos: XYZ, coordinateIndex: Map<string, string>): boolean {
   if (pos.y <= 0) return true
   const below: XYZ = { x: pos.x, y: pos.y - 1, z: pos.z }
-  return ALL_SIDES.some(side => coordinateIndex.has(toEdgeKey(below, side)))
+  if (ALL_SIDES.some(side => coordinateIndex.has(toEdgeKey(below, side)))) return true
+  // Adjacent floor at same level allows extension (balcony)
+  return (
+    coordinateIndex.has(toKey({ x: pos.x - 1, y: pos.y, z: pos.z }))
+    || coordinateIndex.has(toKey({ x: pos.x + 1, y: pos.y, z: pos.z }))
+    || coordinateIndex.has(toKey({ x: pos.x, y: pos.y, z: pos.z - 1 }))
+    || coordinateIndex.has(toKey({ x: pos.x, y: pos.y, z: pos.z + 1 }))
+  )
 }
 
-/** Triangle cell pieces at y>0 need at least one edge piece on the same triangle below. */
+/** Triangle cell pieces at y>0 need wall support below OR an adjacent triangle at the same level. */
 export function hasTriWallSupport(hq: number, y: number, hr: number, slot: number, coordinateIndex: Map<string, string>): boolean {
   if (y <= 0) return true
   for (let edge = 0; edge < 3; edge++) {
     if (coordinateIndex.has(toTriEdgeKey(hq, y - 1, hr, slot, edge))) return true
+  }
+  // Adjacent triangle at same level allows extension (balcony)
+  // Check neighboring slots in the same hex (consecutive slots share an edge)
+  if (coordinateIndex.has(toTriKey(hq, y, hr, (slot + 1) % 6))) return true
+  if (coordinateIndex.has(toTriKey(hq, y, hr, (slot + 5) % 6))) return true
+  // Check neighboring hexes (all 6 directions, all 6 slots)
+  const hexNeighbors = [[1, 0], [-1, 0], [0, 1], [0, -1], [1, -1], [-1, 1]]
+  for (const [dq, dr] of hexNeighbors) {
+    for (let s = 0; s < 6; s++) {
+      if (coordinateIndex.has(toTriKey(hq + dq, y, hr + dr, s))) return true
+    }
   }
   return false
 }

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -1,6 +1,8 @@
 import type { XYZ, FloorConstraint, PlacedPiece, PiecesConfig, PieceSide, TriCoord, TriSnapTarget, SquareSnapTarget } from '../types'
 import { toKey, toEdgeKey, toTriKey, toTriEdgeKey, toTriSnapKey, toTriSnapEdgeKey, toSquareSnapKey, toSquareSnapEdgeKey } from './coordinateKey'
 
+const ALL_SIDES: PieceSide[] = ['north', 'south', 'east', 'west']
+
 const GRID_X = 5
 const GRID_Z = 11
 const GRID_Y = 3
@@ -37,6 +39,60 @@ export function hasFoundation(pos: XYZ, coordinateIndex: Map<string, string>): b
   return coordinateIndex.has(toKey(pos))
 }
 
+/** Upper-floor cell pieces need at least one wall/edge piece at the same cell on the floor below. */
+export function hasWallSupport(pos: XYZ, coordinateIndex: Map<string, string>): boolean {
+  if (pos.y <= 0) return true
+  const below: XYZ = { x: pos.x, y: pos.y - 1, z: pos.z }
+  return ALL_SIDES.some(side => coordinateIndex.has(toEdgeKey(below, side)))
+}
+
+/** Triangle cell pieces at y>0 need at least one edge piece on the same triangle below. */
+export function hasTriWallSupport(hq: number, y: number, hr: number, slot: number, coordinateIndex: Map<string, string>): boolean {
+  if (y <= 0) return true
+  for (let edge = 0; edge < 3; edge++) {
+    if (coordinateIndex.has(toTriEdgeKey(hq, y - 1, hr, slot, edge))) return true
+  }
+  return false
+}
+
+/** Check if a grid cell overlaps any snapped square (different coordinate space). */
+function overlapsSnappedPiece(pos: XYZ, pieces: PlacedPiece[]): boolean {
+  const cx = pos.x + 0.5
+  const cz = pos.z + 0.5
+  for (const piece of pieces) {
+    if (piece.position.y !== pos.y || piece.side) continue
+    if (piece.squareSnap) {
+      const dx = piece.squareSnap.worldX - cx
+      const dz = piece.squareSnap.worldZ - cz
+      if (dx * dx + dz * dz < 0.45 * 0.45) return true
+    }
+    if (piece.triSnap && !piece.triEdge) {
+      const dx = piece.triSnap.worldX - cx
+      const dz = piece.triSnap.worldZ - cz
+      if (dx * dx + dz * dz < 0.4 * 0.4) return true
+    }
+  }
+  return false
+}
+
+/** Check if a snap position overlaps any grid-placed cell piece. */
+function overlapsGridPiece(worldX: number, worldZ: number, y: number, coordinateIndex: Map<string, string>): boolean {
+  const gx = Math.floor(worldX)
+  const gz = Math.floor(worldZ)
+  for (let dx = -1; dx <= 1; dx++) {
+    for (let dz = -1; dz <= 1; dz++) {
+      const key = toKey({ x: gx + dx, y, z: gz + dz })
+      if (!coordinateIndex.has(key)) continue
+      const gcx = gx + dx + 0.5
+      const gcz = gz + dz + 0.5
+      const ddx = worldX - gcx
+      const ddz = worldZ - gcz
+      if (ddx * ddx + ddz * ddz < 0.7 * 0.7) return true
+    }
+  }
+  return false
+}
+
 export function isMaxCountReached(type: string, pieces: PlacedPiece[], config: PiecesConfig): boolean {
   const maxCount = config[type]?.maxCount
   if (maxCount === null || maxCount === undefined) return false
@@ -67,8 +123,12 @@ export function canPlace(
     if (pieceConfig.placementType === 'edge') {
       // Edge piece on a triangle edge
       if (triEdge === undefined) return false
+      if (position.y >= GRID_Y - 1) return false // roof level — no walls
       const foundationKey = toTriKey(triCoord.hq, position.y, triCoord.hr, triCoord.slot)
-      if (!coordinateIndex.has(foundationKey)) return false
+      const hasTriFoundation = coordinateIndex.has(foundationKey)
+      const hasTriEdgeBelow = position.y > 0
+        && coordinateIndex.has(toTriEdgeKey(triCoord.hq, position.y - 1, triCoord.hr, triCoord.slot, triEdge))
+      if (!hasTriFoundation && !hasTriEdgeBelow) return false
       const edgeKey = toTriEdgeKey(triCoord.hq, position.y, triCoord.hr, triCoord.slot, triEdge)
       if (coordinateIndex.has(edgeKey)) return false
       return true
@@ -77,6 +137,7 @@ export function canPlace(
     // Cell piece (triangle foundation)
     const key = toTriKey(triCoord.hq, position.y, triCoord.hr, triCoord.slot)
     if (coordinateIndex.has(key)) return false
+    if (!hasTriWallSupport(triCoord.hq, position.y, triCoord.hr, triCoord.slot, coordinateIndex)) return false
     return true
   }
 
@@ -88,11 +149,16 @@ export function canPlace(
 
   if (pieceConfig.placementType === 'edge') {
     if (!side) return false
+    if (position.y >= GRID_Y - 1) return false // roof level — no walls
     if (isEdgeOccupied(position, side, coordinateIndex)) return false
-    // Edge pieces require a foundation (hull or floor piece) in the cell they attach to
-    if (!hasFoundation(position, coordinateIndex)) return false
+    // Foundation at same cell OR edge piece below on same side (wall stacking)
+    const hasEdgeBelowOnSide = position.y > 0
+      && coordinateIndex.has(toEdgeKey({ x: position.x, y: position.y - 1, z: position.z }, side))
+    if (!hasFoundation(position, coordinateIndex) && !hasEdgeBelowOnSide) return false
   } else {
     if (isCellOccupied(position, coordinateIndex)) return false
+    if (!hasWallSupport(position, coordinateIndex)) return false
+    if (overlapsSnappedPiece(position, pieces)) return false
   }
 
   return true
@@ -112,6 +178,7 @@ export function canPlaceTriSnap(
   // Must not already have a triangle at this snap position
   const snapKey = toTriSnapKey(snap.worldX, snap.y, snap.worldZ)
   if (coordinateIndex.has(snapKey)) return false
+  if (overlapsGridPiece(snap.worldX, snap.worldZ, snap.y, coordinateIndex)) return false
   return true
 }
 
@@ -128,9 +195,13 @@ export function canPlaceTriSnapEdge(
   if (!pieceConfig) return false
   if (!isFloorAllowed({ x: 0, y, z: 0 }, pieceConfig.floorConstraint)) return false
   if (isMaxCountReached(type, pieces, config)) return false
-  // Must have a snap-placed triangle foundation at this position
+  if (y >= GRID_Y - 1) return false // roof level — no walls
+  // Foundation at same position OR edge piece below on same edge (stacking)
   const foundKey = toTriSnapKey(snap.worldX, y, snap.worldZ)
-  if (!coordinateIndex.has(foundKey)) return false
+  const hasSnapFoundation = coordinateIndex.has(foundKey)
+  const hasSnapEdgeBelow = y > 0
+    && coordinateIndex.has(toTriSnapEdgeKey(snap.worldX, y - 1, snap.worldZ, edge))
+  if (!hasSnapFoundation && !hasSnapEdgeBelow) return false
   // Must not already have an edge piece here
   const edgeKey = toTriSnapEdgeKey(snap.worldX, y, snap.worldZ, edge)
   if (coordinateIndex.has(edgeKey)) return false
@@ -150,6 +221,7 @@ export function canPlaceSquareSnap(
   if (isMaxCountReached(type, pieces, config)) return false
   const snapKey = toSquareSnapKey(snap.worldX, snap.y, snap.worldZ)
   if (coordinateIndex.has(snapKey)) return false
+  if (overlapsGridPiece(snap.worldX, snap.worldZ, snap.y, coordinateIndex)) return false
   return true
 }
 
@@ -166,9 +238,13 @@ export function canPlaceSquareSnapEdge(
   if (!pieceConfig) return false
   if (!isFloorAllowed({ x: 0, y, z: 0 }, pieceConfig.floorConstraint)) return false
   if (isMaxCountReached(type, pieces, config)) return false
-  // Must have a snap-placed square foundation at this position
+  if (y >= GRID_Y - 1) return false // roof level — no walls
+  // Foundation at same position OR edge piece below on same side (stacking)
   const foundKey = toSquareSnapKey(snap.worldX, y, snap.worldZ)
-  if (!coordinateIndex.has(foundKey)) return false
+  const hasSnapFoundation = coordinateIndex.has(foundKey)
+  const hasSnapEdgeBelow = y > 0
+    && coordinateIndex.has(toSquareSnapEdgeKey(snap.worldX, y - 1, snap.worldZ, side))
+  if (!hasSnapFoundation && !hasSnapEdgeBelow) return false
   // Must not already have an edge piece here
   const edgeKey = toSquareSnapEdgeKey(snap.worldX, y, snap.worldZ, side)
   if (coordinateIndex.has(edgeKey)) return false

--- a/tests/validation.test.ts
+++ b/tests/validation.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import { canPlace, isTriInBounds } from '../src/utils/validation'
 import type { PlacedPiece, PiecesConfig } from '../src/types'
-import { toTriKey } from '../src/utils/coordinateKey'
+import { toTriKey, toTriEdgeKey } from '../src/utils/coordinateKey'
 import piecesConfig from '../src/data/pieces-config.json'
 
 const config = piecesConfig as PiecesConfig
@@ -63,9 +63,16 @@ describe('canPlace with triCoord', () => {
     expect(result).toBe(false)
   })
 
-  it('allows triangle floor on upper floors', () => {
-    const result = canPlace('floor_triangle', { x: 0, y: 1, z: 0 }, [], new Map(), config, undefined, { hq: 0, hr: 0, slot: 0 })
+  it('allows triangle floor on upper floors with wall support below', () => {
+    // Wall on edge 0 of the same triangle at y=0 provides support
+    const index = new Map([[toTriEdgeKey(0, 0, 0, 0, 0), 'wall-1']])
+    const result = canPlace('floor_triangle', { x: 0, y: 1, z: 0 }, [], index, config, undefined, { hq: 0, hr: 0, slot: 0 })
     expect(result).toBe(true)
+  })
+
+  it('rejects triangle floor on upper floors without wall support', () => {
+    const result = canPlace('floor_triangle', { x: 0, y: 1, z: 0 }, [], new Map(), config, undefined, { hq: 0, hr: 0, slot: 0 })
+    expect(result).toBe(false)
   })
 
   it('rejects unknown piece type', () => {


### PR DESCRIPTION
## Summary
- **Wall stacking UX**: hovering over an existing wall/window/doorway during edge placement shows a ghost and allows placing on the level above
- **Floor-on-wall placement**: hovering over walls with a floor piece selected places the floor on the level above, works with all floor levels visible
- **Floor extension (balcony)**: upper floors can extend from adjacent floors without walls below — enables overhanging decks and balconies
- **Multi-floor snap scanning**: snap functions scan all visible upper floors for targets, so placement at y=2 works without hiding lower levels; prefers higher floors on distance tie
- **Triangle-to-triangle snap fix**: uses closest-candidate selection instead of fixed priority chain, so triangle floors correctly chain off other triangles
- **Wall variant models**: distinct EdgeMesh geometry for cannon wall (cutout) and fence barrier (horizontal planks)
- **Validation improvements**: edge stacking without intermediate floors, roof-level wall restriction (y=2), click-to-select disabled during placement mode

Closes #21, closes #22

## Test plan
- [ ] Place hull + walls at y=0, hover over walls with floor selected → floor ghost appears at y=1
- [ ] Extend floor at y=1 by clicking adjacent empty cells → balcony pattern works
- [ ] Place walls at y=1, hover with floor selected → floor at y=2
- [ ] Extend floor at y=2 with all floors visible → works without hiding lower levels
- [ ] Triangle→square→triangle snap chains work in all directions
- [ ] Wall/window/doorway stacking by hovering over existing edges
- [ ] Cannon wall and fence barrier render with distinct shapes
- [ ] All 108 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)