### PR TITLE
chore: rename project to Rust Build Planner

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# Rust Naval Boat Builder
+# Rust Build Planner
 
-A 3D boat builder for [Rust](https://rust.facepunch.com/). Design naval vessels by placing hulls, floors, walls, and deployables, then share your builds via URL.
+A 3D build planner for [Rust](https://rust.facepunch.com/). Design naval vessels and land bases by placing hulls, floors, walls, and deployables, then share your builds via URL.
 
-**[Try it live](https://curtyo18.github.io/rust-naval-boat-builder/)**
+**[Try it live](https://curtyo18.github.io/rust-build-planner/)**
 
 ## Features
 
@@ -30,7 +30,7 @@ npm install
 npm run dev
 ```
 
-Open http://localhost:5173/rust-naval-boat-builder/
+Open http://localhost:5173/rust-build-planner/
 
 ## Scripts
 

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Rust Naval Boat Builder</title>
+    <title>Rust Build Planner</title>
   </head>
   <body>
     <div id="root"></div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "rust-naval-boat-builder",
+  "name": "rust-build-planner",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "rust-naval-boat-builder",
+      "name": "rust-build-planner",
       "version": "1.0.0",
       "dependencies": {
         "@react-three/drei": "^10.7.7",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "rust-naval-boat-builder",
+  "name": "rust-build-planner",
   "private": true,
   "version": "1.0.0",
   "type": "module",

--- a/src/core/ui/TopBar.tsx
+++ b/src/core/ui/TopBar.tsx
@@ -13,7 +13,7 @@ interface TopBarProps {
 export default function TopBar({ onResetCamera, onShare, onClear, shareLabel = 'Share', modeId, onModeChange }: TopBarProps) {
   return (
     <header className="topbar">
-      <span className="topbar__title">Rust Naval Planner</span>
+      <span className="topbar__title">Rust Build Planner</span>
       <select
         className="topbar__mode"
         value={modeId}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,7 +4,7 @@ import react from '@vitejs/plugin-react'
 
 export default defineConfig({
   plugins: [react()],
-  base: '/rust-naval-boat-builder/',
+  base: '/rust-build-planner/',
   server: {
     hmr: false,
   },


### PR DESCRIPTION
## Summary
- Renames package, README, in-app title, page title, and Vite base path from `rust-naval-boat-builder` to `rust-build-planner`
- Reflects that the app now covers both naval boat building and base building (since #28)
- Single mechanical-rename commit; preserves `LEGACY_KEY = 'naval-planner-design'` localStorage migration string

## Test plan
- [ ] CI lint + build green
- [ ] After merge, gh-pages deploy publishes build with new base path
- [ ] After repo rename (separate step), new URL serves the app and share links round-trip in both modes