### PR TITLE
chore(#30,#31): lint cleanup and CI Node bump

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,11 +11,11 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
 
       - run: npm ci
@@ -23,6 +23,7 @@ jobs:
       - run: npm run build
 
       - name: Deploy to gh-pages
+        # Pinned to v4 pending a Node-24-compatible release of peaceiris/actions-gh-pages.
         uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/src/core/scene/PlacedPieces.tsx
+++ b/src/core/scene/PlacedPieces.tsx
@@ -172,7 +172,7 @@ export default function PlacedPieces() {
             onPointerOver: () => setStackTargetId(piece.id),
             onPointerOut: () => setStackTargetId((p) => p === piece.id ? null : p),
             onClick: (ev: { stopPropagation: () => void; delta?: number }) => {
-              if ((ev as any).delta > 5) return
+              if ((ev.delta ?? 0) > 5) return
               ev.stopPropagation()
               if (canStack && canStackOn(piece)) placeOnTop(piece)
               else if (canFloor && canFloorAbove(piece)) placeFloorAbove(piece)
@@ -255,7 +255,7 @@ export default function PlacedPieces() {
             onPointerOver: () => setStackTargetId(piece.id),
             onPointerOut: () => setStackTargetId((p) => p === piece.id ? null : p),
             onClick: (ev: { stopPropagation: () => void; delta?: number }) => {
-              if ((ev as any).delta > 5) return
+              if ((ev.delta ?? 0) > 5) return
               ev.stopPropagation()
               if (canStack && canStackOn(piece)) placeOnTop(piece)
               else if (canFloor && canFloorAbove(piece)) placeFloorAbove(piece)
@@ -329,7 +329,7 @@ export default function PlacedPieces() {
             onPointerOver: () => setStackTargetId(piece.id),
             onPointerOut: () => setStackTargetId((p) => p === piece.id ? null : p),
             onClick: (ev: { stopPropagation: () => void; delta?: number }) => {
-              if ((ev as any).delta > 5) return
+              if ((ev.delta ?? 0) > 5) return
               ev.stopPropagation()
               if (canStack && canStackOn(piece)) placeOnTop(piece)
               else if (canFloor && canFloorAbove(piece)) placeFloorAbove(piece)
@@ -403,7 +403,7 @@ export default function PlacedPieces() {
             onPointerOver: () => setStackTargetId(piece.id),
             onPointerOut: () => setStackTargetId((p) => p === piece.id ? null : p),
             onClick: (ev: { stopPropagation: () => void; delta?: number }) => {
-              if ((ev as any).delta > 5) return
+              if ((ev.delta ?? 0) > 5) return
               ev.stopPropagation()
               if (canStack && canStackOn(piece)) placeOnTop(piece)
               else if (canFloor && canFloorAbove(piece)) placeFloorAbove(piece)


### PR DESCRIPTION
## Summary

- Drop four redundant `(ev as any).delta > 5` casts in `PlacedPieces.tsx`; the local `ev` parameter is already typed `{ stopPropagation: () => void; delta?: number }`, so a null-safe `(ev.delta ?? 0) > 5` works without `any`.
- Bump `.github/workflows/deploy.yml` off Node 20 ahead of GitHub''s 2026-06-02 forced switch to Node 24 / 2026-09-16 removal of Node 20:
  - `actions/checkout@v4` → `@v5`
  - `actions/setup-node@v4` → `@v5`
  - `node-version: 20` → `22` (active LTS)
  - `peaceiris/actions-gh-pages` left at `@v4` with a one-line comment — no Node-24-compatible major has been published yet.

## Test plan

- [ ] `npm run lint` exits 0 with no `@typescript-eslint/no-explicit-any` errors
- [ ] `npm test` — existing 155 tests still pass
- [ ] `npm run build` succeeds on Node 22
- [ ] After squash-merge: `gh run list --workflow=deploy.yml --limit 1` deploy is green with no Node 20 deprecation annotations
- [ ] https://curtyo18.github.io/rust-build-planner/ — boat and base modes render and click-to-place still works

Closes #30
Closes #31